### PR TITLE
deferred processing for better performance of android

### DIFF
--- a/android/src/main/java/com/ultralytics/ultralytics_yolo/CameraPreview.java
+++ b/android/src/main/java/com/ultralytics/ultralytics_yolo/CameraPreview.java
@@ -19,6 +19,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.ultralytics.ultralytics_yolo.predict.Predictor;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 
 public class CameraPreview {
@@ -30,14 +33,16 @@ public class CameraPreview {
     private Activity activity;
     private PreviewView mPreviewView;
     private boolean busy = false;
+    private boolean deferredProcessing = false;
 
     public CameraPreview(Context context) {
         this.context = context;
     }
 
-    public void openCamera(int facing, Activity activity, PreviewView mPreviewView) {
+    public void openCamera(int facing, Activity activity, PreviewView mPreviewView, boolean deferredProcessing) {
         this.activity = activity;
         this.mPreviewView = mPreviewView;
+        this.deferredProcessing = deferredProcessing;
 
         final ListenableFuture<ProcessCameraProvider> cameraProviderFuture = ProcessCameraProvider.getInstance(context);
         cameraProviderFuture.addListener(() -> {
@@ -55,6 +60,8 @@ public class CameraPreview {
         if (!busy) {
             busy = true;
 
+            final boolean isMirrored = (facing == CameraSelector.LENS_FACING_FRONT);
+
             Preview cameraPreview = new Preview.Builder()
                     .setTargetAspectRatio(AspectRatio.RATIO_4_3)
                     .build();
@@ -65,15 +72,42 @@ public class CameraPreview {
 
             ImageAnalysis imageAnalysis =
                     new ImageAnalysis.Builder()
-                            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                            .setBackpressureStrategy(deferredProcessing ? ImageAnalysis.STRATEGY_BLOCK_PRODUCER : ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                             .setTargetAspectRatio(AspectRatio.RATIO_4_3)
                             .build();
-            imageAnalysis.setAnalyzer(Runnable::run, imageProxy -> {
-                predictor.predict(imageProxy, facing == CameraSelector.LENS_FACING_FRONT);
 
-                //clear stream for next image
-                imageProxy.close();
-            });
+            if (deferredProcessing) {
+                final ExecutorService executorService = Executors.newSingleThreadExecutor();
+                final AtomicBoolean isPredicting = new AtomicBoolean(false);
+
+                imageAnalysis.setAnalyzer(Runnable::run, imageProxy -> {
+                    if (isPredicting.get()) {
+                        imageProxy.close();
+                        return;
+                    }
+
+                    isPredicting.set(true);
+
+                    executorService.submit(() -> {
+                        try {
+                            predictor.predict(imageProxy, isMirrored);
+                        } catch (Exception e) {
+                          e.printStackTrace();
+                        } finally {
+                            //clear stream for next image
+                            imageProxy.close();
+
+                            isPredicting.set(false);
+                        }
+                    });
+                });
+            } else {
+                imageAnalysis.setAnalyzer(Runnable::run, imageProxy -> {
+                    predictor.predict(imageProxy, isMirrored);
+                    //clear stream for next image
+                    imageProxy.close();
+                });
+            }
 
             // Unbind use cases before rebinding
             cameraProvider.unbindAll();

--- a/android/src/main/java/com/ultralytics/ultralytics_yolo/NativeView.java
+++ b/android/src/main/java/com/ultralytics/ultralytics_yolo/NativeView.java
@@ -25,11 +25,12 @@ class NativeView implements PlatformView {
 
         final int lensDirection = (int) creationParams.get("lensDirection");
 //        final String format = (String) creationParams.get("format");
+        final boolean deferredProcessing = (boolean) creationParams.getOrDefault("deferredProcessing", false);
 
 //        if (Objects.requireNonNull(format).equals("tflite")) {
         view = LayoutInflater.from(context).inflate(R.layout.activity_tflite_camera, null);
         mPreviewView = view.findViewById(R.id.previewView);
-        startTfliteCamera(lensDirection);
+        startTfliteCamera(lensDirection, deferredProcessing);
 //        }
 
     }
@@ -44,7 +45,7 @@ class NativeView implements PlatformView {
     public void dispose() {
     }
 
-    private void startTfliteCamera(int facing) {
-        cameraPreview.openCamera(facing, activity, mPreviewView);
+    private void startTfliteCamera(int facing, boolean deferredProcessing) {
+        cameraPreview.openCamera(facing, activity, mPreviewView, deferredProcessing);
     }
 }

--- a/lib/camera_preview/ultralytics_yolo_camera_controller.dart
+++ b/lib/camera_preview/ultralytics_yolo_camera_controller.dart
@@ -7,6 +7,7 @@ class UltralyticsYoloCameraValue {
   UltralyticsYoloCameraValue({
     required this.lensDirection,
     required this.strokeWidth,
+    required this.deferredProcessing,
   });
 
   /// The direction of the camera lens
@@ -15,15 +16,20 @@ class UltralyticsYoloCameraValue {
   /// The width of the stroke used to draw the bounding boxes
   final double strokeWidth;
 
+  /// Whether the processing of the frames should be deferred (android only)
+  final bool deferredProcessing;
+
   /// Creates a copy of this [UltralyticsYoloCameraValue] but with
   /// the given fields
   UltralyticsYoloCameraValue copyWith({
     int? lensDirection,
     double? strokeWidth,
+    bool? deferredProcessing,
   }) =>
       UltralyticsYoloCameraValue(
         lensDirection: lensDirection ?? this.lensDirection,
         strokeWidth: strokeWidth ?? this.strokeWidth,
+        deferredProcessing: deferredProcessing ?? this.deferredProcessing,
       );
 }
 
@@ -31,11 +37,12 @@ class UltralyticsYoloCameraValue {
 class UltralyticsYoloCameraController
     extends ValueNotifier<UltralyticsYoloCameraValue> {
   /// Constructor to create an instance of [UltralyticsYoloCameraController]
-  UltralyticsYoloCameraController()
+  UltralyticsYoloCameraController({bool deferredProcessing = false})
       : super(
           UltralyticsYoloCameraValue(
             lensDirection: 1,
             strokeWidth: 2.5,
+            deferredProcessing: deferredProcessing,
           ),
         );
 

--- a/lib/camera_preview/ultralytics_yolo_camera_preview.dart
+++ b/lib/camera_preview/ultralytics_yolo_camera_preview.dart
@@ -73,6 +73,8 @@ class _UltralyticsYoloCameraPreviewState
               final creationParams = <String, dynamic>{
                 'lensDirection': widget.controller.value.lensDirection,
                 'format': widget.predictor?.model.format.name,
+                'deferredProcessing':
+                    widget.controller.value.deferredProcessing,
               };
 
               switch (defaultTargetPlatform) {


### PR DESCRIPTION
Added delayed prediction processing feature for smooth camera frame rendering on Android. After analyzing the ImageAnalysis code of Android, it expected that frame dropout would occur if the analyzer logic declared with setAnalyzer is not processed as fast as possible even if "ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST" is used.
If "deferredProcessing" mode is used, the requested analyze is skipped while the prediction is processed in the sub thread.