### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
 on:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically publishes a new repository tag and release
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,3 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 include: package:very_good_analysis/analysis_options.5.1.0.yaml

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # This file configures the analyzer, which statically analyzes Dart code to
 # check for errors, warnings, and lints.
 #

--- a/example/assets/metadata-cls.yaml
+++ b/example/assets/metadata-cls.yaml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 description: Ultralytics YOLOv8n-cls model trained on ../datasets/imagenet
 author: Ultralytics
 license: AGPL-3.0 https://ultralytics.com/license

--- a/example/assets/metadata.yaml
+++ b/example/assets/metadata.yaml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 description: Ultralytics YOLOv8n model trained on coco.yaml
 author: Ultralytics
 license: AGPL-3.0 https://ultralytics.com/license

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: ultralytics_yolo_example
 description: Demonstrates how to use the ultralytics_yolo plugin.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: ultralytics_yolo
 description: A Flutter plugin for Ultralytics YOLO computer vision models
 version: 0.0.3


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves clarity and consistency in license attributions across the project. 📝🚀  

### 📊 Key Changes  
- Updated license headers in multiple files to consistently reference the Ultralytics AGPL-3.0 License with a URL to the license. 🌍  
- Added missing license attributions to analysis configuration (`analysis_options.yaml`), example assets, and project metadata files. 🛠️  

### 🎯 Purpose & Impact  
- **Purpose:** Ensure proper and consistent attribution of the AGPL-3.0 license across all files, aligning with open-source licensing best practices. ✅  
- **Impact:** Enhances transparency for users and contributors about the licensing terms, promoting better compliance and trust. 🙌 No functional changes to the code or user-facing features were introduced. 🚫🖥️