### PR TITLE
Remove OpenCV mentions in ultralytics.h

### DIFF
--- a/android/src/main/cpp/ultralytics.h
+++ b/android/src/main/cpp/ultralytics.h
@@ -7,8 +7,6 @@
 #ifndef ANDROID_ULTRALYTICS_H
 #define ANDROID_ULTRALYTICS_H
 
-#include <opencv2/core/core.hpp>
-
 struct DetectedObject {
     cv::Rect_<float> rect;
     int index;


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed an unused OpenCV header from the native Android code to streamline the project. 🧹

### 📊 Key Changes
- Deleted the `#include <opencv2/core/core.hpp>` line from the `ultralytics.h` file.

### 🎯 Purpose & Impact
- Reduces unnecessary dependencies, making the codebase cleaner and potentially improving build times.
- Minimizes the risk of future compatibility issues with unused libraries.
- Helps keep the project lightweight and easier to maintain for developers.