### PR TITLE
Resolve astral uv warnings in publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
         with:
-          ignore-empty-workdir: true
+          enable-cache: false
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pubdev
         shell: python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
+        with:
+          ignore-empty-workdir: true
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pubdev
         shell: python


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved the GitHub Actions workflow to handle empty work directories more gracefully during publishing. 🚀

### 📊 Key Changes  
- Updated the workflow to set `ignore-empty-workdir: true` when setting up the `uv` environment.

### 🎯 Purpose & Impact  
- Prevents workflow failures if the working directory is empty, making automated publishing more robust and reliable.  
- Reduces interruptions for developers and ensures smoother CI/CD processes.