### PR TITLE
Add optional threshold parameters to single image inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,47 @@ YOLO({
 });
 ```
 
+##### Methods
+
+###### loadModel()
+Loads the YOLO model for inference. Must be called before `predict()`.
+
+```dart
+final yolo = YOLO(modelPath: 'yolo11n', task: YOLOTask.detect);
+await yolo.loadModel();
+```
+
+###### predict()
+Runs inference on a single image with optional threshold parameters. The thresholds are only applied for this specific prediction and do not affect subsequent predictions.
+
+```dart
+// Basic usage with default thresholds
+final results = await yolo.predict(imageBytes);
+
+// Usage with custom thresholds (only for this prediction)
+final results = await yolo.predict(
+  imageBytes,
+  confidenceThreshold: 0.6,  // Optional: 0.0-1.0, defaults to 0.25
+  iouThreshold: 0.5,         // Optional: 0.0-1.0, defaults to 0.4
+);
+
+// Process results
+final boxes = results['boxes'] as List<Map<String, dynamic>>;
+for (var box in boxes) {
+  print('Class: ${box['class']}, Confidence: ${box['confidence']}');
+}
+```
+
+###### Static Methods
+
+```dart
+// Check if a model exists at the specified path
+final exists = await YOLO.checkModelExists('yolo11n');
+
+// Get available storage paths
+final paths = await YOLO.getStoragePaths();
+```
+
 #### YOLOViewController
 
 Controller for interacting with a YOLOView, managing settings like thresholds.

--- a/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
@@ -362,15 +362,17 @@ class ObjectDetector(
 
     // Thresholds (like setConfidenceThreshold, setIouThreshold in TFLiteDetector)
     private var confidenceThreshold = 0.25f
-    private var iouThreshold = 0.45f
+    private var iouThreshold = 0.4f
     private var numItemsThreshold = 30
 
-    fun setConfidenceThreshold(conf: Float) {
-        confidenceThreshold = conf
+    override fun setConfidenceThreshold(conf: Double) {
+        confidenceThreshold = conf.toFloat()
+        super.setConfidenceThreshold(conf)
     }
 
-    fun setIouThreshold(iou: Float) {
-        iouThreshold = iou
+    override fun setIouThreshold(iou: Double) {
+        iouThreshold = iou.toFloat()
+        super.setIouThreshold(iou)
     }
 
     override fun setNumItemsThreshold(n: Int) {

--- a/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
@@ -40,7 +40,7 @@ abstract class BasePredictor : Predictor {
     protected var t4: Double = 0.0
 
     var CONFIDENCE_THRESHOLD:Float = 0.25f
-    var IOU_THRESHOLD:Float = 0.25f
+    var IOU_THRESHOLD:Float = 0.4f
     var transformationMatrix: Matrix? = null
     var pendingBitmapFrame: Bitmap? = null
 
@@ -52,11 +52,11 @@ abstract class BasePredictor : Predictor {
         t3 = now
     }
     override fun setIouThreshold(iou: Double) {
-
+        IOU_THRESHOLD = iou.toFloat()
     }
 
     override fun setConfidenceThreshold(conf: Double) {
-
+        CONFIDENCE_THRESHOLD = conf.toFloat()
     }
 
     override fun setNumItemsThreshold(progress: Int) {

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -256,12 +256,12 @@ class YOLOView @JvmOverloads constructor(
 
     fun setConfidenceThreshold(conf: Double) {
         confidenceThreshold = conf
-        (predictor as? ObjectDetector)?.setConfidenceThreshold(conf.toFloat())
+        (predictor as? ObjectDetector)?.setConfidenceThreshold(conf)
     }
 
     fun setIouThreshold(iou: Double) {
         iouThreshold = iou
-        (predictor as? ObjectDetector)?.setIouThreshold(iou.toFloat())
+        (predictor as? ObjectDetector)?.setIouThreshold(iou)
     }
 
     fun setNumItemsThreshold(n: Int) {
@@ -291,8 +291,8 @@ class YOLOView @JvmOverloads constructor(
             try {
                 val newPredictor = when (task) {
                     YOLOTask.DETECT -> ObjectDetector(context, modelPath, loadLabels(modelPath), useGpu = true).apply {
-                        setConfidenceThreshold(confidenceThreshold.toFloat())
-                        setIouThreshold(iouThreshold.toFloat())
+                        setConfidenceThreshold(confidenceThreshold)
+                        setIouThreshold(iouThreshold)
                         setNumItemsThreshold(numItemsThreshold)
                     }
                     YOLOTask.SEGMENT -> Segmenter(context, modelPath, loadLabels(modelPath), useGpu = true)

--- a/ios/Classes/YOLO.swift
+++ b/ios/Classes/YOLO.swift
@@ -19,6 +19,26 @@ import UIKit
 /// The primary interface for working with YOLO models, supporting multiple input types and inference methods.
 public class YOLO {
   var predictor: Predictor!
+  
+  /// Confidence threshold for filtering predictions (0.0-1.0)
+  public var confidenceThreshold: Double = 0.25 {
+    didSet {
+      // Apply to predictor if it has been loaded
+      if let basePredictor = predictor as? BasePredictor {
+        basePredictor.setConfidenceThreshold(confidence: confidenceThreshold)
+      }
+    }
+  }
+  
+  /// IoU threshold for non-maximum suppression (0.0-1.0)
+  public var iouThreshold: Double = 0.4 {
+    didSet {
+      // Apply to predictor if it has been loaded
+      if let basePredictor = predictor as? BasePredictor {
+        basePredictor.setIouThreshold(iou: iouThreshold)
+      }
+    }
+  }
 
   public init(
     _ modelPathOrName: String, task: YOLOTask, completion: ((Result<YOLO, Error>) -> Void)? = nil

--- a/ios/Classes/YOLOPlugin.swift
+++ b/ios/Classes/YOLOPlugin.swift
@@ -176,12 +176,28 @@ class SingleImageYOLO {
     return modelPath
   }
 
-  func predict(imageData: Data) -> [String: Any]? {
+  func predict(imageData: Data, confidenceThreshold: Double? = nil, iouThreshold: Double? = nil) -> [String: Any]? {
     guard let yolo = self.yolo, let uiImage = UIImage(data: imageData) else {
       return nil
     }
+    
+    // Store original thresholds
+    let originalConfThreshold = yolo.confidenceThreshold
+    let originalIouThreshold = yolo.iouThreshold
+    
+    // Apply custom thresholds if provided
+    if let confThreshold = confidenceThreshold {
+      yolo.confidenceThreshold = confThreshold
+    }
+    if let iouThreshold = iouThreshold {
+      yolo.iouThreshold = iouThreshold
+    }
 
     let result = yolo(uiImage)
+    
+    // Restore original thresholds
+    yolo.confidenceThreshold = originalConfThreshold
+    yolo.iouThreshold = originalIouThreshold
 
     return convertToFlutterFormat(result: result)
   }
@@ -387,8 +403,16 @@ public class YOLOPlugin: NSObject, FlutterPlugin {
               code: "bad_args", message: "Invalid arguments for predictSingleImage", details: nil))
           return
         }
+        
+        // Extract optional threshold parameters
+        let confidenceThreshold = args["confidenceThreshold"] as? Double
+        let iouThreshold = args["iouThreshold"] as? Double
 
-        if let resultDict = SingleImageYOLO.shared.predict(imageData: data.data) {
+        if let resultDict = SingleImageYOLO.shared.predict(
+          imageData: data.data,
+          confidenceThreshold: confidenceThreshold,
+          iouThreshold: iouThreshold
+        ) {
           result(resultDict)
         } else {
           result(

--- a/lib/yolo.dart
+++ b/lib/yolo.dart
@@ -152,7 +152,16 @@ class YOLO {
   ///
   /// Example:
   /// ```dart
+  /// // Basic usage with default thresholds
   /// final results = await yolo.predict(imageBytes);
+  /// 
+  /// // Usage with custom thresholds
+  /// final results = await yolo.predict(
+  ///   imageBytes,
+  ///   confidenceThreshold: 0.6,
+  ///   iouThreshold: 0.5,
+  /// );
+  /// 
   /// final boxes = results['boxes'] as List<Map<String, dynamic>>;
   /// for (var box in boxes) {
   ///   print('Class: ${box['class']}, Confidence: ${box['confidence']}');
@@ -162,19 +171,43 @@ class YOLO {
   /// Returns a map containing the inference results. If inference fails, throws an exception.
   ///
   /// @param imageBytes The raw image data as a Uint8List
+  /// @param confidenceThreshold Optional confidence threshold (0.0-1.0). Defaults to 0.25 if not specified.
+  /// @param iouThreshold Optional IoU threshold for NMS (0.0-1.0). Defaults to 0.4 if not specified.
   /// @return A map containing the inference results
   /// @throws [ModelNotLoadedException] if the model has not been loaded
   /// @throws [InferenceException] if there's an error during inference
   /// @throws [PlatformException] if there's an issue with the platform-specific code
-  Future<Map<String, dynamic>> predict(Uint8List imageBytes) async {
+  Future<Map<String, dynamic>> predict(
+    Uint8List imageBytes, {
+    double? confidenceThreshold,
+    double? iouThreshold,
+  }) async {
     if (imageBytes.isEmpty) {
       throw InvalidInputException('Image data is empty');
     }
 
+    // Validate threshold values if provided
+    if (confidenceThreshold != null && (confidenceThreshold < 0.0 || confidenceThreshold > 1.0)) {
+      throw InvalidInputException('Confidence threshold must be between 0.0 and 1.0');
+    }
+    if (iouThreshold != null && (iouThreshold < 0.0 || iouThreshold > 1.0)) {
+      throw InvalidInputException('IoU threshold must be between 0.0 and 1.0');
+    }
+
     try {
-      final result = await _channel.invokeMethod('predictSingleImage', {
+      final Map<String, dynamic> arguments = {
         'image': imageBytes,
-      });
+      };
+      
+      // Add optional thresholds if provided
+      if (confidenceThreshold != null) {
+        arguments['confidenceThreshold'] = confidenceThreshold;
+      }
+      if (iouThreshold != null) {
+        arguments['iouThreshold'] = iouThreshold;
+      }
+      
+      final result = await _channel.invokeMethod('predictSingleImage', arguments);
 
       if (result is Map) {
         // Convert Map<Object?, Object?> to Map<String, dynamic>


### PR DESCRIPTION
- Add confidenceThreshold and iouThreshold parameters to YOLO.predict()
- Default values: confidence=0.25, IoU=0.4
- Thresholds are applied only for the specific prediction and restored after
- Update Android native code to handle threshold parameters
- Update iOS native code to handle threshold parameters
- Fix type mismatches in Android predictor implementations
- Add comprehensive documentation in README
- Validate threshold values are between 0.0 and 1.0

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
