### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -2,6 +2,9 @@
 
 name: Dart Analyzer
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolo-flutter-app/security/code-scanning/13](https://github.com/ultralytics/yolo-flutter-app/security/code-scanning/13)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only analyzes Dart code and installs dependencies, it does not require write access to the repository. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents without granting write access. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
