### PR TITLE
fix: properly stop camera on YOLOView

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -205,6 +205,17 @@ class YOLOPlatformView(
                     Log.d(TAG, "YOLOView streaming config updated: $streamConfig")
                     result.success(null)
                 }
+                                "stop" -> {
+                    Log.d(TAG, "Received manual stop call from Flutter")
+                    try {
+                        yoloView.stop()
+                        Log.d(TAG, "YOLOView stopped successfully via method call")
+                        result.success(null)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error stopping YOLOView via method call", e)
+                        result.error("stop_error", "Error stopping YOLOView: ${e.message}", null)
+                    }
+                }
                 else -> {
                     Log.w(TAG, "Method not implemented: ${call.method}")
                     result.notImplemented()
@@ -351,10 +362,25 @@ class YOLOPlatformView(
 
     override fun dispose() {
         Log.d(TAG, "Disposing YOLOPlatformView for viewId: $viewId")
-        // Clean up resources
-        methodChannel?.setMethodCallHandler(null)
-        // Notify the factory that this view is disposed
-        factory.onPlatformViewDisposed(viewId)
+
+        try {
+            // Stop camera and inference before disposing
+            Log.d(TAG, "Calling yoloView.stop() to stop camera and inference")
+            yoloView.stop()
+
+            // Clean up method channel
+            Log.d(TAG, "Clearing method channel handler")
+            methodChannel?.setMethodCallHandler(null)
+
+            // Notify the factory that this view is disposed
+            Log.d(TAG, "Notifying factory of disposal")
+            factory.onPlatformViewDisposed(viewId)
+
+            Log.d(TAG, "YOLOPlatformView disposal completed successfully")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error during YOLOPlatformView disposal", e)
+        }
     }
 
     /**

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -1319,4 +1319,37 @@ class YOLOView @JvmOverloads constructor(
     }
     
     // endregion
+
+    /**
+     * Stop camera and inference (can be restarted later)
+     */
+    fun stop() {
+        Log.d(TAG, "YOLOView.stop() called - stopping camera and inference")
+
+        try {
+            // Stop camera operations
+            if (::cameraProviderFuture.isInitialized) {
+                Log.d(TAG, "Unbinding camera use cases")
+                val cameraProvider = cameraProviderFuture.get()
+                cameraProvider.unbindAll()
+                Log.d(TAG, "Camera successfully unbound")
+            }
+            camera = null
+
+            // Clear predictor (but keep it restartable)
+            Log.d(TAG, "Clearing predictor")
+            predictor = null
+
+            // Clear callbacks to prevent memory leaks
+            Log.d(TAG, "Clearing callbacks and result data")
+            inferenceCallback = null
+            streamCallback = null
+            inferenceResult = null
+
+            Log.d(TAG, "YOLOView stop completed successfully")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error during YOLOView stop", e)
+        }
+    }
 }

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -411,7 +411,7 @@ class YOLOViewController {
       logInfo('YOLOViewController: Error setting streaming config: $e');
     }
   }
-}
+
 
   /// Stop camera and inference operations.
   ///
@@ -439,7 +439,7 @@ class YOLOViewController {
       logInfo('YOLOViewController: Error stopping camera and inference: $e');
     }
   }
-
+}
 /// A Flutter widget that displays a real-time camera preview with YOLO object detection.
 ///
 /// This widget creates a platform view that runs YOLO inference on camera frames

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -413,6 +413,33 @@ class YOLOViewController {
   }
 }
 
+  /// Stop camera and inference operations.
+  ///
+  /// This method stops the camera preview and inference processing,
+  /// but keeps the view in a state where it could potentially be
+  /// restarted. For complete cleanup, the widget disposal process
+  /// will call this automatically plus additional cleanup.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Stop camera and inference temporarily
+  /// await controller.stop();
+  /// ```
+  Future<void> stop() async {
+    if (_methodChannel == null) {
+      logInfo(
+        'YOLOViewController: Warning - Cannot stop, view not yet created',
+      );
+      return;
+    }
+    try {
+      await _methodChannel!.invokeMethod('stop');
+      logInfo('YOLOViewController: Camera and inference stopped successfully');
+    } catch (e) {
+      logInfo('YOLOViewController: Error stopping camera and inference: $e');
+    }
+  }
+
 /// A Flutter widget that displays a real-time camera preview with YOLO object detection.
 ///
 /// This widget creates a platform view that runs YOLO inference on camera frames
@@ -655,11 +682,10 @@ class YOLOViewState extends State<YOLOView> {
 
   @override
   void dispose() {
-    // TODO: Uncomment when stop() method is available
     // Stop camera and inference before disposing
-    // _effectiveController.stop().catchError((e) {
-    //   logInfo('YOLOView: Error stopping camera during dispose: $e');
-    // });
+    _effectiveController.stop().catchError((e) {
+      logInfo('YOLOView: Error stopping camera during dispose: $e');
+    });
 
     // Cancel event subscriptions
     _cancelResultSubscription();


### PR DESCRIPTION
This PR fixes an issue where the native camera continues running after the Flutter view is disposed.

#### ✅ Changes:
- Implemented `stop()` method in `YOLOView.kt` to unbind cameraProvider.
- Exposed `stop()` via MethodChannel in `YOLOPlatformView`.
- Called `yoloView.stop()` from `dispose()` to ensure clean shutdown.

#### ✅ CLA
I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added a new method to safely stop the camera and inference in the YOLO Flutter app, improving resource management and app stability. 🛑📱

### 📊 Key Changes
- Introduced a `stop()` method in both the Android and Dart (Flutter) code to halt camera and inference operations without fully disposing of the view.
- Updated the disposal process to automatically call `stop()` before cleaning up resources.
- Improved error handling and logging during the stop and disposal processes.
- Exposed the `stop()` method to Flutter developers via the `YOLOViewController`.

Related Issues

https://github.com/ultralytics/yolo-flutter-app/issues/225

### 🎯 Purpose & Impact
- 🧹 **Better Resource Management:** Prevents resource leaks by ensuring the camera and inference are properly stopped when not needed or before disposal.
- 🚦 **Flexible Control:** Developers can now pause and resume camera/inference operations without destroying the view, enabling smoother user experiences.
- 🛡️ **Increased Stability:** Enhanced error handling reduces the risk of crashes or unexpected behavior during cleanup.
- 👩‍💻 **Developer Convenience:** The new method is easy to use and well-documented, making it straightforward for Flutter developers to manage camera resources in their apps.