### PR TITLE
fix: resolve camera connection not closing when YOLOView disposes

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -205,6 +205,17 @@ class YOLOPlatformView(
                     Log.d(TAG, "YOLOView streaming config updated: $streamConfig")
                     result.success(null)
                 }
+                "stop" -> {
+                    Log.d(TAG, "Received manual stop call from Flutter")
+                    try {
+                        yoloView.stop()
+                        Log.d(TAG, "YOLOView stopped successfully via method call")
+                        result.success(null)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error stopping YOLOView via method call", e)
+                        result.error("stop_error", "Error stopping YOLOView: ${e.message}", null)
+                    }
+                }
                 else -> {
                     Log.w(TAG, "Method not implemented: ${call.method}")
                     result.notImplemented()
@@ -351,10 +362,25 @@ class YOLOPlatformView(
 
     override fun dispose() {
         Log.d(TAG, "Disposing YOLOPlatformView for viewId: $viewId")
-        // Clean up resources
-        methodChannel?.setMethodCallHandler(null)
-        // Notify the factory that this view is disposed
-        factory.onPlatformViewDisposed(viewId)
+
+        try {
+            // Stop camera and inference before disposing
+            Log.d(TAG, "Calling yoloView.stop() to stop camera and inference")
+            yoloView.stop()
+
+            // Clean up method channel
+            Log.d(TAG, "Clearing method channel handler")
+            methodChannel?.setMethodCallHandler(null)
+
+            // Notify the factory that this view is disposed
+            Log.d(TAG, "Notifying factory of disposal")
+            factory.onPlatformViewDisposed(viewId)
+
+            Log.d(TAG, "YOLOPlatformView disposal completed successfully")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error during YOLOPlatformView disposal", e)
+        }
     }
 
     /**

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -411,6 +411,33 @@ class YOLOViewController {
       logInfo('YOLOViewController: Error setting streaming config: $e');
     }
   }
+
+  /// Stop camera and inference operations.
+  ///
+  /// This method stops the camera preview and inference processing,
+  /// but keeps the view in a state where it could potentially be
+  /// restarted. For complete cleanup, the widget disposal process
+  /// will call this automatically plus additional cleanup.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Stop camera and inference temporarily
+  /// await controller.stop();
+  /// ```
+  Future<void> stop() async {
+    if (_methodChannel == null) {
+      logInfo(
+        'YOLOViewController: Warning - Cannot stop, view not yet created',
+      );
+      return;
+    }
+    try {
+      await _methodChannel!.invokeMethod('stop');
+      logInfo('YOLOViewController: Camera and inference stopped successfully');
+    } catch (e) {
+      logInfo('YOLOViewController: Error stopping camera and inference: $e');
+    }
+  }
 }
 
 /// A Flutter widget that displays a real-time camera preview with YOLO object detection.
@@ -655,11 +682,10 @@ class YOLOViewState extends State<YOLOView> {
 
   @override
   void dispose() {
-    // TODO: Uncomment when stop() method is available
     // Stop camera and inference before disposing
-    // _effectiveController.stop().catchError((e) {
-    //   logInfo('YOLOView: Error stopping camera during dispose: $e');
-    // });
+    _effectiveController.stop().catchError((e) {
+      logInfo('YOLOView: Error stopping camera during dispose: $e');
+    });
 
     // Cancel event subscriptions
     _cancelResultSubscription();


### PR DESCRIPTION
Fixed camera connection not closed after YOLOView widget is disposed **(Only for Android platform)**.
Thanks for @sadtearcat, I've modified his/her initial code to ensure camera disposal.