### PR TITLE
Removed example/assets dependency from the plugin's pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,3 @@ flutter:
         pluginClass: YOLOPlugin
       ios:
         pluginClass: YOLOPlugin
-  assets:
-    - example/assets/


### PR DESCRIPTION

## Description
Removed unnecessary example/assets dependency that was causing build issues.

## Changes
- Removed example/assets from pubspec.yaml

Fixes #286 #287 