### PR TITLE
feat: add bounding box drawing to pose single image inference

### DIFF
--- a/ios/Classes/Plot.swift
+++ b/ios/Classes/Plot.swift
@@ -629,7 +629,7 @@ func drawPoseOnCIImage(
     let path = UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius)
     currentContext.addPath(path.cgPath)
     currentContext.strokePath()
-    
+
     // Draw label
     let confidencePercent = Int(box.conf * 100)
     let labelText = "\(box.cls) \(confidencePercent)%"


### PR DESCRIPTION
Fixed an issue where the result drawing was misaligned when the model size was non-square.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label placement for bounding boxes in pose detection on iOS, ensuring labels stay visible and don’t overlap image edges. 🖼️✨

### 📊 Key Changes
- Updated the drawing logic for bounding box labels to prevent them from being placed outside the image boundary.
- Removed unnecessary enumeration over bounding boxes for cleaner code.
- Labels now automatically adjust their position if they would appear off the top edge of the image.

### 🎯 Purpose & Impact
- Enhances user experience by ensuring all labels are fully visible on the screen.
- Prevents important information from being cut off, making results clearer and easier to interpret.
- Results in a more polished and professional appearance for pose detection outputs on iOS devices.