### PR TITLE
fix: handle potential out-of-bounds access for angle calculation in O…

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
@@ -241,7 +241,7 @@ class ObbDetector(
             }
 
             val angleIndex = 4 + numClasses
-            val angle = data[angleIndex]
+            val angle = if (angleIndex < data.size) data[angleIndex] else 0f
 
             if (bestScore >= confidenceThreshold) {
                 val obb = OBB(cx, cy, w, h, angle)


### PR DESCRIPTION
Models exported from Roboflow often do not include the `angle` output in their TFLite weight files. This leads to a crash in the plugin on Android when the output tensor is accessed out of bounds. iOS, however, continues to function as expected.

This change ensures that if the `angle` tensor is missing or the access is out of bounds, a default value of zero is safely used instead. This prevents the crash and maintains consistent behavior across platforms.