### PR TITLE
Fix onResult callback receiving empty results when streamingConfig not provided

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -122,20 +122,33 @@ class YOLOPlatformView(
     private fun setupYOLOViewStreaming(creationParams: Map<String?, Any?>?) {
         val streamingConfigParam = creationParams?.get("streamingConfig") as? Map<*, *>
         
-        val streamConfig = streamingConfigParam?.let { config ->
+        val streamConfig = if (streamingConfigParam != null) {
             YOLOStreamConfig(
-                includeDetections = config["includeDetections"] as? Boolean ?: true,
-                includeClassifications = config["includeClassifications"] as? Boolean ?: true,
-                includeProcessingTimeMs = config["includeProcessingTimeMs"] as? Boolean ?: true,
-                includeFps = config["includeFps"] as? Boolean ?: true,
-                includeMasks = config["includeMasks"] as? Boolean ?: false,
-                includePoses = config["includePoses"] as? Boolean ?: false,
-                includeOBB = config["includeOBB"] as? Boolean ?: false,
-                includeOriginalImage = config["includeOriginalImage"] as? Boolean ?: false,
-                maxFPS = (config["maxFPS"] as? Number)?.toInt(),
-                throttleIntervalMs = (config["throttleInterval"] as? Number)?.toInt(),
-                inferenceFrequency = (config["inferenceFrequency"] as? Number)?.toInt(),
-                skipFrames = (config["skipFrames"] as? Number)?.toInt()
+                includeDetections = streamingConfigParam["includeDetections"] as? Boolean ?: true,
+                includeClassifications = streamingConfigParam["includeClassifications"] as? Boolean ?: true,
+                includeProcessingTimeMs = streamingConfigParam["includeProcessingTimeMs"] as? Boolean ?: true,
+                includeFps = streamingConfigParam["includeFps"] as? Boolean ?: true,
+                includeMasks = streamingConfigParam["includeMasks"] as? Boolean ?: false,
+                includePoses = streamingConfigParam["includePoses"] as? Boolean ?: false,
+                includeOBB = streamingConfigParam["includeOBB"] as? Boolean ?: false,
+                includeOriginalImage = streamingConfigParam["includeOriginalImage"] as? Boolean ?: false,
+                maxFPS = (streamingConfigParam["maxFPS"] as? Number)?.toInt(),
+                throttleIntervalMs = (streamingConfigParam["throttleInterval"] as? Number)?.toInt(),
+                inferenceFrequency = (streamingConfigParam["inferenceFrequency"] as? Number)?.toInt(),
+                skipFrames = (streamingConfigParam["skipFrames"] as? Number)?.toInt()
+            )
+        } else {
+            // Create default config when no streaming config is provided
+            // This ensures onResult callback receives detection data
+            YOLOStreamConfig(
+                includeDetections = true,
+                includeClassifications = true,
+                includeProcessingTimeMs = true,
+                includeFps = true,
+                includeMasks = false,
+                includePoses = false,
+                includeOBB = false,
+                includeOriginalImage = false
             )
         }
         


### PR DESCRIPTION
⏺ PR: Fix onResult callback receiving empty results when streamingConfig not
   provided

  Summary

  Fixes #[issue] where onResult callback in YOLOView widget always receives
  empty results when streamingConfig parameter is not explicitly provided,
  even though bounding boxes are correctly displayed on the camera preview.

  Problem

  Users reported that the onResult callback was not receiving any detection
  results (always empty list) when using YOLOView without providing a
  streamingConfig parameter:

  YOLOView(
    modelPath: 'assets/models/yolov8n.tflite',
    onResult: (results) {
      // results.length was always 0
    },
  )

  Root Cause

  The bug was introduced in commit 9476e1d (#322) during refactoring. When
  streamingConfig is not provided:
  - Before: Used YOLOStreamConfig.DEFAULT as fallback
  - After: streamConfig became null, causing convertResultToStreamData() to
  return an empty map

  The native overlay rendering worked correctly (bounding boxes visible)
  because it's independent of the streaming mechanism.

  Solution

  Always create a default YOLOStreamConfig when none is provided, ensuring
  detection data is sent to Flutter:

  // Before (broken)
  val streamConfig = streamingConfigParam?.let { config ->
      YOLOStreamConfig(...)
  }
  // streamConfig is null when streamingConfigParam is null

  // After (fixed)
  val streamConfig = if (streamingConfigParam != null) {
      YOLOStreamConfig(...)
  } else {
      // Default config ensures onResult receives data
      YOLOStreamConfig(
          includeDetections = true,
          includeClassifications = true,
          includeProcessingTimeMs = true,
          includeFps = true
      )
  }

  Testing

  Tested with the example app:
  - ✅ onResult callback receives detection results without streamingConfig
  - ✅ onResult callback works with custom streamingConfig
  - ✅ Backward compatibility maintained
  - ✅ iOS already had proper defaults (no changes needed)

  Impact

  - Severity: High - Core functionality broken for 2+ months
  - Affected versions: v0.1.25 - v0.1.36 (since Aug 11, 2025)
  - Affected users: Anyone using onResult without explicit streamingConfig

  Workaround (for affected versions)

  Until this fix is released, users can work around the issue by explicitly
  providing a streamingConfig:

  YOLOView(
    streamingConfig: YOLOStreamConfig(), // Add this line
    onResult: (results) {
      // Now receives results correctly
    },
  )

  Checklist

  - Bug fix (non-breaking change which fixes an issue)
  - Tested on Android device
  - Tested on Android emulator
  - iOS testing not required (already working)
  - Code follows project style guidelines
  - No unnecessary comments or debug code

  Closes #342 

- Always create a default YOLOStreamConfig when none is provided
- Ensures detection data is sent to Flutter for onResult callback
- Fixes issue where bounding boxes were visible but onResult was empty
- Android now matches iOS behavior which already had proper defaults

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds safe defaults for streaming when no config is provided, ensuring consistent results and smoother out-of-the-box behavior on Android. ✅

### 📊 Key Changes
- Introduces a default `YOLOStreamConfig` when `streamingConfig` is null, enabling:
  - Detections, classifications, processing time, and FPS included by default
  - Masks, poses, OBB, and original image disabled by default
- Refactors config parsing to use `streamingConfigParam` directly, reducing potential null/typing issues
- Maintains support for optional parameters like `maxFPS`, `throttleInterval`, `inferenceFrequency`, and `skipFrames`

### 🎯 Purpose & Impact
- Ensures `onResult` callback reliably receives detection data even without a provided config 🎯
- Improves developer experience: works out of the box without requiring `streamingConfig` setup 🧩
- Reduces risk of null-related issues or silent failures in streaming pipelines 🛡️
- Backward-compatible: existing custom configs continue to work as before 🔄