### PR TITLE
Fix build errors and permissions granted notification (Android)

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
@@ -48,6 +48,12 @@ abstract class BasePredictor : Predictor {
     var pendingBitmapFrame: Bitmap? = null
     var isFrontCamera: Boolean = false
 
+    fun close() {
+        if (isInterpreterInitialized()) {
+            interpreter.close()
+        }
+    }
+
     protected fun updateTiming() {
         val now = System.nanoTime()
         val dt = (now - t0) / 1e9

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
@@ -483,6 +483,7 @@ class YOLOPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCallHandler
             // Assuming only one view actively requests permissions at a time.
             // If multiple views could request, 'handled' logic might need adjustment
             // or ensure only the correct view processes it.
+            platformView.yoloViewInstance.onRequestPermissionsResult(requestCode, permissions, grantResults)
         } catch (e: Exception) {
             Log.e(TAG, "Error processing permission result for YOLOPlatformView instance", e)
         }

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -1449,7 +1449,7 @@ class YOLOView @JvmOverloads constructor(
     /**
      * Flattens keypoints data into a single array format: [x1, y1, conf1, x2, y2, conf2, ...]
      */
-    private fun flattenKeypoints(keypoints: YOLOResult.Keypoints): List<Double> {
+    private fun flattenKeypoints(keypoints: Keypoints): List<Double> {
         val flattened = mutableListOf<Double>()
         for (i in keypoints.xy.indices) {
             flattened.add(keypoints.xy[i].first.toDouble())
@@ -1794,7 +1794,7 @@ class YOLOView @JvmOverloads constructor(
             cameraExecutor = null
 
             camera = null
-            predictor?.close()
+            (predictor as? BasePredictor)?.close()
             predictor = null
             inferenceCallback = null
             streamCallback = null


### PR DESCRIPTION
### Description
This PR addresses two categories of issues in the current main branch:

1. **Build errors when compiling the APK**

The following errors occur when building the example app:

```
/yolo-flutter-app/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt:1452:56 Unresolved reference: Keypoints
/yolo-flutter-app/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt:1797:24 Unresolved reference: close
```

**Changes made to fix these**:

- **YOLOView.kt**
Updated the function signature for flattenKeypoints:

```
- private fun flattenKeypoints(keypoints: YOLOResult.Keypoints): List<Double>
+ private fun flattenKeypoints(keypoints: Keypoints): List<Double>
```

- **Predictor.kt**
Implemented a close() function in the base Predictor class:

```
fun close() {
    if (isInterpreterInitialized()) {
        interpreter.close()
    }
}
```

- **YOLOView.kt**
Updated stop() function to safely call close():

`(predictor as? BasePredictor)?.close()  // instead of predictor?.close()`

2. **Camera permissions not properly initializing the view**

After granting camera permissions, the view was not notified, so the camera would not start until a manual action like switching the camera occurred.

**Changes made to fix this:**

- **YOLOPlugin.kt**
Added a call to notify the YoloView instance when permissions are granted:

`platformView.yoloViewInstance.onRequestPermissionsResult(requestCode, permissions, grantResults)`


### Impact:

Fixes APK build errors caused by unresolved references.

Ensures that camera permissions trigger proper initialization of the camera view.

### Testing:

Verified that the app builds successfully on Android.

Verified that the camera starts correctly immediately after granting permissions.
