### PR TITLE
Fix iOS performance metrics not updating in YOLOView

### DIFF
--- a/example/lib/presentation/screens/camera_inference_screen.dart
+++ b/example/lib/presentation/screens/camera_inference_screen.dart
@@ -28,8 +28,6 @@ class _CameraInferenceScreenState extends State<CameraInferenceScreen> {
   double _iouThreshold = 0.45;
   int _numItemsThreshold = 30;
   double _currentFps = 0.0;
-  int _frameCount = 0;
-  DateTime _lastFpsUpdate = DateTime.now();
   SliderType _activeSlider = SliderType.none;
   ModelType _selectedModel = ModelType.detect;
   bool _isModelLoading = false;
@@ -68,15 +66,9 @@ class _CameraInferenceScreenState extends State<CameraInferenceScreen> {
   /// - FPS calculation
   void _onDetectionResults(List<YOLOResult> results) {
     if (!mounted) return;
-    _frameCount++;
-    final now = DateTime.now();
-    final elapsed = now.difference(_lastFpsUpdate).inMilliseconds;
-    if (elapsed >= 1000) {
-      _currentFps = _frameCount * 1000 / elapsed;
-      _frameCount = 0;
-      _lastFpsUpdate = now;
-    }
-    setState(() => _detectionCount = results.length);
+    setState(() {
+      _detectionCount = results.length;
+    });
   }
 
   @override

--- a/ios/Classes/SwiftYOLOPlatformView.swift
+++ b/ios/Classes/SwiftYOLOPlatformView.swift
@@ -426,31 +426,22 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
     // Use the parsed stream config (no more hardcoding)
     let finalStreamConfig = streamConfig
 
-    print(
-      "SwiftYOLOPlatformView: 🔍 Final stream config - includeOriginalImage: \(finalStreamConfig.includeOriginalImage)"
-    )
-
     // Configure YOLOView with the stream config
     yoloView.setStreamConfig(finalStreamConfig)
 
     // Set up streaming callback to forward data to Flutter via event channel
     yoloView.setStreamCallback { [weak self] streamData in
-      // Forward streaming data from YOLOView to Flutter
       self?.sendStreamDataToFlutter(streamData)
     }
   }
 
   /// Send stream data to Flutter via event channel
   private func sendStreamDataToFlutter(_ streamData: [String: Any]) {
-
     guard let eventSink = self.eventSink else {
-
       return
     }
 
-    // Send event on main thread
     DispatchQueue.main.async {
-
       eventSink(streamData)
     }
   }
@@ -464,14 +455,11 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
     -> FlutterError?
   {
-
     self.eventSink = events
-
     return nil
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-
     self.eventSink = nil
     return nil
   }

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -1560,7 +1560,7 @@ extension YOLOView: AVCapturePhotoCaptureDelegate {
   /// Uses detection index correctly to avoid class index confusion
   private func convertResultToStreamData(_ result: YOLOResult) -> [String: Any] {
     var map: [String: Any] = [:]
-    guard let config = streamConfig else { return map }
+    let config = streamConfig ?? YOLOStreamConfig.DEFAULT
 
     // Convert detection results (if enabled)
     if config.includeDetections {
@@ -1717,11 +1717,11 @@ extension YOLOView: AVCapturePhotoCaptureDelegate {
 
     // Add performance metrics (if enabled)
     if config.includeProcessingTimeMs {
-      map["processingTimeMs"] = currentProcessingTime  // inference time in ms
+      map["processingTimeMs"] = result.speed * 1000
     }
 
     if config.includeFps {
-      map["fps"] = currentFps  // FPS value
+      map["fps"] = result.fps ?? 0.0
     }
 
     if config.includeOriginalImage {

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -450,7 +450,7 @@ class YOLOViewController {
         'includeOBB': config.includeOBB,
         'includeOriginalImage': config.includeOriginalImage,
         'maxFPS': config.maxFPS,
-        'throttleInterval': config.throttleInterval?.inMilliseconds,
+        'throttleIntervalMs': config.throttleInterval?.inMilliseconds,
         'inferenceFrequency': config.inferenceFrequency,
         'skipFrames': config.skipFrames,
       });
@@ -752,12 +752,6 @@ class YOLOViewState extends State<YOLOView> {
 
     _setupController();
 
-    if (widget.onResult != null ||
-        widget.onPerformanceMetrics != null ||
-        widget.onStreamingData != null) {
-      _subscribeToResults();
-    }
-
     // Apply initial streaming config if provided
     if (widget.streamingConfig != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -936,21 +930,12 @@ class YOLOViewState extends State<YOLOView> {
   }
 
   void _subscribeToResults() {
-    // Don't recreate subscription if one already exists and is working
-    if (_resultSubscription != null && mounted) {
-      logInfo(
-        'YOLOView: Subscription already exists, skipping recreation for $_viewId',
-      );
-      return;
-    }
-
     _cancelResultSubscription();
 
     logInfo(
       'YOLOView: Setting up event stream listener for channel: ${_resultEventChannel.name}',
     );
 
-    // Cancel any existing subscription timer
     _subscriptionTimer?.cancel();
 
     try {
@@ -1140,7 +1125,7 @@ class YOLOViewState extends State<YOLOView> {
 
     // Add streaming config to creation params if provided
     if (widget.streamingConfig != null) {
-      final streamConfig = {
+      final streamConfig = <String, dynamic>{
         'includeDetections': widget.streamingConfig!.includeDetections,
         'includeClassifications':
             widget.streamingConfig!.includeClassifications,
@@ -1151,10 +1136,24 @@ class YOLOViewState extends State<YOLOView> {
         'includePoses': widget.streamingConfig!.includePoses,
         'includeOBB': widget.streamingConfig!.includeOBB,
         'includeOriginalImage': widget.streamingConfig!.includeOriginalImage,
-        'maxFPS': widget.streamingConfig!.maxFPS,
-        'throttleInterval':
-            widget.streamingConfig!.throttleInterval?.inMilliseconds,
       };
+
+      // Only include optional parameters if they are not null
+      if (widget.streamingConfig!.maxFPS != null) {
+        streamConfig['maxFPS'] = widget.streamingConfig!.maxFPS;
+      }
+      if (widget.streamingConfig!.throttleInterval != null) {
+        streamConfig['throttleIntervalMs'] =
+            widget.streamingConfig!.throttleInterval!.inMilliseconds;
+      }
+      if (widget.streamingConfig!.inferenceFrequency != null) {
+        streamConfig['inferenceFrequency'] =
+            widget.streamingConfig!.inferenceFrequency;
+      }
+      if (widget.streamingConfig!.skipFrames != null) {
+        streamConfig['skipFrames'] = widget.streamingConfig!.skipFrames;
+      }
+
       creationParams['streamingConfig'] = streamConfig;
     }
 


### PR DESCRIPTION
- Fix EventChannel subscription timing: Move subscription from initState to _onPlatformViewCreated to ensure iOS EventChannel is ready
- Fix streaming config key mismatch: Change 'throttleInterval' to 'throttleIntervalMs' to match iOS expectations
- Fix performance metrics source: Use result.fps and result.speed directly instead of stored values to avoid race conditions
- Add fallback to YOLOStreamConfig.DEFAULT when streamConfig is nil
- Simplify example app FPS display to use onPerformanceMetrics callback only

This fixes the issue where FPS and detection count labels were not updating on iOS devices.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined and corrected real-time metrics streaming (FPS and processing time), improved config handling, and cleaned up iOS event streaming for a more reliable YOLO Flutter integration. ⚡📱

### 📊 Key Changes
- Flutter example (CameraInferenceScreen):
  - Removed local FPS calculation; now relies on streamed metrics from the native layer. 🎥
- iOS (SwiftYOLOPlatformView.swift):
  - Cleaned up prints/comments and simplified event streaming to Flutter. Less noise, same behavior. 🧹
- iOS (YOLOView.swift):
  - Safely falls back to a default stream config when none is provided.
  - Fixes metrics mapping:
    - `processingTimeMs` now uses `result.speed * 1000`.
    - `fps` now uses `result.fps` (defaults to 0.0 if missing). ✅
- Dart (yolo_view.dart):
  - Renamed platform channel key to `throttleIntervalMs` (from `throttleInterval`) when passing to native.
  - Only includes optional streaming params in creation params if they’re set (avoids sending nulls).
  - Ensures clean stream subscription handling by always canceling then re-subscribing when needed.
  - Strongly types the streaming config map sent to the platform.

### 🎯 Purpose & Impact
- More accurate and consistent performance metrics (FPS and processing time) across platforms. 📈
- Improved stability: default config prevents crashes or empty outputs when a stream config isn’t supplied. 🛡️
- Cleaner platform communication: correct key names and no null clutter reduce integration issues. 🔧
- Predictable event subscriptions: avoids duplicate or stale listeners, improving reliability under config changes. 🔁
- Developer experience: fewer logs and clearer behavior; typical Flutter users don’t need to change app code. Advanced users sending raw platform maps should use `throttleIntervalMs`. 💡

Example (no changes needed for typical usage):
```dart
final streamingConfig = YOLOStreamingConfig(
  includeDetections: true,
  includeFps: true,
  includeProcessingTimeMs: true,
  throttleInterval: const Duration(milliseconds: 100), // Dart API stays the same
);
```