### PR TITLE
Update format.yml to `ubuntu-latest`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,8 @@ permissions:
 
 jobs:
   actions:
-    runs-on: macos-26
+    # Run on ubuntu as problems with docformatter on macOS-26 with Python 3.14
+    runs-on: ubuntu-latest
     steps:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main
@@ -28,7 +29,7 @@ jobs:
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff and docformatter
           prettier: true # Format YAML, JSON, Markdown, CSS
-          swift: true # Format Swift (requires macos-latest)
+          swift: false # Format Swift (requires macos-latest)
           dart: true # Format Dart/Flutter
           spelling: true # Check spelling with codespell
           links: false # Check broken links with Lychee


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switches the formatting CI from macOS to Ubuntu for reliability, and temporarily disables Swift formatting to avoid macOS/Python 3.14 issues. 🚦

### 📊 Key Changes
- CI runner changed from `macos-26` to `ubuntu-latest` due to docformatter issues on macOS with Python 3.14 🐧
- Swift formatting turned off (`swift: false`) since it requires a macOS runner 📴
- Other formatters remain enabled: Python (Ruff + docformatter), Prettier, Dart/Flutter, and spelling checks ✅

### 🎯 Purpose & Impact
- Improves CI stability and speeds up formatting checks by using Ubuntu runners ⚡
- Prevents CI failures caused by docformatter on macOS-26 with Python 3.14 🛠️
- Slight trade-off: Swift files won’t be auto-formatted in CI; consider a separate macOS job if Swift formatting is needed for iOS code 📱
- No impact on application runtime; this only affects developer workflow and code quality enforcement ✅