### PR TITLE
chore: expose isInitialized

### DIFF
--- a/lib/yolo.dart
+++ b/lib/yolo.dart
@@ -40,10 +40,9 @@ class YOLO {
   /// The unique instance ID for this YOLO instance
   String get instanceId => _instanceId;
 
-  /// Returns `true` if initialization has been attempted (via [loadModel] or
-  /// automatically in the constructor), `false` otherwise. This can be used to
-  /// check if initialization has been started before calling [predict] to avoid
-  /// catching [ModelNotLoadedException].
+  /// Returns `true` if the model has been successfully loaded via [loadModel],
+  /// `false` otherwise. This can be used to check if the model is ready before
+  /// calling [predict] to avoid catching [ModelNotLoadedException].
   bool get isInitialized => _isInitialized;
 
   /// Path to the YOLO model file. This can be:
@@ -93,7 +92,6 @@ class YOLO {
       YOLOInstanceManager.registerInstance(_instanceId, this);
     } else {
       _instanceId = 'default';
-      _isInitialized = true;
     }
 
     _initializeComponents();
@@ -156,10 +154,11 @@ class YOLO {
   ///
   /// throws [ModelLoadingException] if the model file cannot be found
   Future<bool> loadModel() async {
-    if (!_isInitialized) {
+    final success = await _modelManager.loadModel();
+    if (success) {
       _isInitialized = true;
     }
-    return await _modelManager.loadModel();
+    return success;
   }
 
   /// Runs inference on a single image.
@@ -212,7 +211,12 @@ class YOLO {
     double? iouThreshold,
   }) async {
     if (!_isInitialized) {
-      await loadModel();
+      final success = await loadModel();
+      if (!success) {
+        throw ModelNotLoadedException(
+          'Model failed to load. Cannot perform inference.',
+        );
+      }
     }
     return await _inference.predict(
       imageBytes,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves model initialization flow by adding a readiness flag, ensuring `loadModel()` sets state only on success, and making `predict()` fail fast with a clear error if the model isn’t loaded. ✅

### 📊 Key Changes
- ✅ Added `isInitialized` getter to check if the model is ready before calling `predict()`.
- 🧠 Removed premature `_isInitialized = true` for the default instance; initialization now only happens after a successful `loadModel()`.
- 🔁 Updated `loadModel()` to:
  - Return a boolean indicating success.
  - Set `_isInitialized` to `true` only when model loading succeeds.
- 🛡️ Strengthened `predict()`:
  - Attempts `loadModel()` if not initialized.
  - Throws a `ModelNotLoadedException` with a clear message if loading fails.

### 🎯 Purpose & Impact
- 🧪 More reliable readiness checks: Developers can safely gate inference with `yolo.isInitialized` or `await yolo.loadModel()`.
- 🚫 Fewer silent failures: Predict now fails fast with a helpful exception if the model isn’t loaded, improving debuggability.
- 🔄 Clearer lifecycle: Initialization state reflects real loading status, reducing confusion and hidden side effects.
- ⚠️ Potential behavior change: Code that relied on the default instance being implicitly “initialized” must now call `loadModel()` or handle the new exception path.