### PR TITLE
fix: update iOS version check for experimentalMLE5EngineUsage from 16 to 17

### DIFF
--- a/ios/Classes/BasePredictor.swift
+++ b/ios/Classes/BasePredictor.swift
@@ -138,7 +138,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
           config.computeUnits = .cpuOnly
         }
 
-        if #available(iOS 16.0, *) {
+        if #available(iOS 17.0, *) {
           config.setValue(1, forKey: "experimentalMLE5EngineUsage")
         }
 


### PR DESCRIPTION
# Problem Description  
When running the app on iOS 16 and earlier versions, the following error occurs:  
```
[<MLModelConfiguration 0x2814ad540> setValue:forUndefinedKey:]: this class is not key value coding-compliant for the key experimentalMLE5EngineUsage.'
```
After checking, it was found that a value was assigned to the `experimentalMLE5EngineUsage` field in the configuration file in `BasePredictor.swift`, and this configuration field seems to be available only from iOS 17 onwards. Refer to [this issue](https://github.com/ultralytics/ultralytics/issues/5165).  

# Solution  
I upgraded the condition of the iOS version in the judgment, changing  
```swift
#available(iOS 16.0, *)
 ```
to
```swift
#available(iOS 17.0, *) 
```
The error was resolved in practical tests.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Update the iOS availability check so `experimentalMLE5EngineUsage` is only enabled on iOS 17 and above, aligning with the correct OS support level.

### 📊 Key Changes
- Adjusts the `#available` check in `BasePredictor.swift` from `iOS 16.0` to `iOS 17.0` when setting `config.setValue(1, forKey: "experimentalMLE5EngineUsage")`.
- Ensures the experimental Core ML engine configuration is gated behind the correct minimum iOS version.

### 🎯 Purpose & Impact
- Avoids potential runtime issues or undefined behavior on iOS 16 devices by not enabling unsupported experimental engine options.
- Improves stability and compatibility for users running the iOS Flutter predictor on older iOS versions.
- Keeps the app aligned with current iOS platform requirements for advanced Core ML features.
