### PR TITLE
Fix Android Flutter embedding resolution on newer SDKs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,21 +24,6 @@ allprojects {
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
-// Flutter SDK path
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    // Try to get Flutter root from environment variable
-    flutterRoot = System.getenv('FLUTTER_ROOT')
-}
-
 android {
     namespace = "com.ultralytics.yolo"
     compileSdk = 36
@@ -87,17 +72,6 @@ android {
     }
 
     dependencies {
-        // Flutter embedding - continue build even if not found in CI environment
-        if (flutterRoot) {
-            compileOnly files("$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar")
-            compileOnly files("$flutterRoot/bin/cache/artifacts/engine/android-arm64/flutter.jar") 
-            compileOnly files("$flutterRoot/bin/cache/artifacts/engine/android-x86/flutter.jar")
-            compileOnly files("$flutterRoot/bin/cache/artifacts/engine/android-x64/flutter.jar")
-        } else {
-            // If Flutter SDK not found, use embedding-release as fallback
-            compileOnly 'io.flutter:flutter_embedding_release:1.0.0-ee76268252c22f5c11e82a7b87423ca3982e51a7'
-        }
-        
         implementation("com.google.ai.edge.litert:litert:1.4.2")
         implementation("com.google.ai.edge.litert:litert-gpu:1.4.2")
         implementation('com.google.ai.edge.litert:litert-support-api:1.4.2')


### PR DESCRIPTION
I ran into two Android build issues ( #455 and this one) today and the coding agent suggested that both are things that should be resolved in the `ultralytics_yolo` package itself.

cc @john-rocky since you added this `build.gradle` config ca a year ago.

---

Coding agent:

## Summary

This removes the plugin's hard-coded Android flutter.jar lookup from android/build.gradle.

The current build script prefers legacy local SDK paths like bin/cache/artifacts/engine/android-arm/flutter.jar whenever flutter.sdk or FLUTTER_ROOT is set. Those paths are no longer present in newer Flutter SDKs such as Flutter 3.41.x, which causes Android builds to fail before the plugin can compile.

Modern Flutter plugin templates no longer declare these manual embedding dependencies. Letting Flutter and Gradle provide the embedding is the compatible path for current SDKs and avoids coupling the plugin to obsolete engine cache layouts.

## Changes
- remove the unused flutter.sdk and FLUTTER_ROOT lookup from the Android plugin Gradle file
- remove the manual compileOnly files(.../flutter.jar) dependencies
- remove the fallback hard-coded io.flutter:flutter_embedding_release coordinate

Note: example/android/ultralytics_yolo_plugin is a symlink to android, so the single tracked Gradle change covers both locations.

## Validation
- confirmed the issue on local Flutter 3.41.4, where the legacy android-arm/flutter.jar paths are absent
- compared against a fresh Flutter 3.41.4 plugin template, which no longer declares explicit embedding dependencies
- ran cd example && flutter build apk --debug
- the build now gets past the stale flutter.jar resolution path and fails later on an unrelated Android Gradle Plugin metadata mismatch (AGP 8.6.0 vs dependencies requiring 8.9.1+)

## Context
This addresses the second Android compatibility problem discussed alongside issue #455. The Java 17 toolchain requirement remains a separate issue.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 Simplifies Android Gradle configuration to fix Flutter embedding resolution issues on newer SDK setups.

### 📊 Key Changes
- Removed manual Flutter SDK path discovery from `android/build.gradle` using `local.properties` and `FLUTTER_ROOT`.
- Removed conditional `compileOnly` references to architecture-specific `flutter.jar` files.
- Removed fallback dependency on `io.flutter:flutter_embedding_release`.
- Kept LiteRT and related Android dependencies unchanged.

### 🎯 Purpose & Impact
- Fixes Android build compatibility on newer Flutter and SDK environments where older embedding resolution logic can fail.
- Reduces Gradle complexity and avoids brittle SDK-specific path handling.
- Improves maintainability by relying on the modern Flutter/Gradle integration instead of legacy embedding workarounds.
- Helps contributors and CI environments build more reliably across updated Android toolchains. 