### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.build.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
@@ -130,7 +130,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `ultralytics_yolo ${{ needs.check.outputs.current_tag }}` pub.dev package published 🎉\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.build.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
       - name: Notify Success
         if: success() && github.event.inputs.publish_tag == 'true'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows to use a newer version of the Slack notification action for release and tagging pipelines.

### 📊 Key Changes
- Upgraded `slackapi/slack-github-action` from `v3.0.1` to `v3.0.2` in `.github/workflows/publish.yml`
- Upgraded `slackapi/slack-github-action` from `v3.0.1` to `v3.0.2` in `.github/workflows/tag.yml`
- Applied the update to both success and failure Slack notification steps where applicable 📣
- No app code, Flutter features, or model-related functionality was changed

### 🎯 Purpose & Impact
- Improves CI/CD workflow maintenance by keeping a third-party GitHub Action up to date 🛠️
- May include minor fixes, security patches, or reliability improvements from the Slack action maintainers 🔒
- Helps ensure publish and tag notifications continue working smoothly for the team’s release process ✅
- Low-risk change for users, since it only affects internal GitHub automation and not the shipped mobile app 📱