### PR TITLE
Fix iOS Swift compile error from trailing comma in loadModel call

### DIFF
--- a/ios/Classes/YOLOPlugin.swift
+++ b/ios/Classes/YOLOPlugin.swift
@@ -284,7 +284,7 @@ public class YOLOPlugin: NSObject, FlutterPlugin {
               modelName: modelPath,
               task: task,
               useGpu: useGpu,
-              numItemsThreshold: numItemsThreshold,
+              numItemsThreshold: numItemsThreshold
             ) { modelResult in
               switch modelResult {
               case .success:


### PR DESCRIPTION
Trailing commas in function call argument lists require Swift 6.1 (Xcode 16.3+). On older toolchains this fails with:
  Swift Compiler Error: Unexpected ',' separator
  ios/Classes/YOLOPlugin.swift:287:12

Remove the trailing comma after the last argument of YOLOInstanceManager.shared.loadModel(...) to restore compatibility with older Xcode versions.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an iOS Swift compilation error in `YOLOPlugin.swift` by removing an invalid trailing comma from the `loadModel` call. 🍎🛠️

### 📊 Key Changes
- Removed the trailing comma after `numItemsThreshold: numItemsThreshold` in `ios/Classes/YOLOPlugin.swift`.
- Preserved the existing `loadModel` invocation logic and callback handling.
- Scoped the change to a single-line Swift syntax fix for iOS builds.

### 🎯 Purpose & Impact
- Resolves a Swift compile error that could block iOS app builds. ✅
- Improves reliability for contributors and users building the Flutter app on iOS. 📱
- Keeps the fix minimal and low risk since no runtime behavior or model logic is changed. 🎯