### PR TITLE
Fix iOS CoreML useGpu handling

### DIFF
--- a/doc/use_gpu_feature.md
+++ b/doc/use_gpu_feature.md
@@ -10,7 +10,7 @@ The default is still:
 useGpu: true
 ```
 
-That is usually the best choice for performance, but CPU-only mode is useful when a device-specific GPU path is unstable.
+That is usually the best choice for performance, but disabling GPU is useful when a device-specific GPU path is unstable.
 
 ## Basic Usage
 
@@ -49,7 +49,7 @@ Disable GPU when:
 ### iOS
 
 - `useGpu: true` uses broader Core ML compute units
-- `useGpu: false` restricts execution to CPU-only mode
+- `useGpu: false` avoids the GPU path
 
 ## Recommendation
 

--- a/ios/Classes/BasePredictor.swift
+++ b/ios/Classes/BasePredictor.swift
@@ -189,8 +189,12 @@ public class BasePredictor: Predictor, @unchecked Sendable {
           // Enable GPU acceleration
           config.computeUnits = .all
         } else {
-          // Force CPU only for stability on problematic devices
-          config.computeUnits = .cpuOnly
+          // Avoid GPU while keeping Neural Engine acceleration available.
+          if #available(iOS 16.0, *) {
+            config.computeUnits = .cpuAndNeuralEngine
+          } else {
+            config.computeUnits = .cpuOnly
+          }
         }
 
         if #available(iOS 17.0, *) {

--- a/ios/Classes/SwiftYOLOPlatformView.swift
+++ b/ios/Classes/SwiftYOLOPlatformView.swift
@@ -79,6 +79,7 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
       let confidenceThreshold = dict["confidenceThreshold"] as? Double ?? 0.25
       let iouThreshold = dict["iouThreshold"] as? Double ?? 0.7
       let numItemsThreshold = dict["numItemsThreshold"] as? Int ?? 30
+      let useGpu = dict["useGpu"] as? Bool ?? true
       let showOverlays = dict["showOverlays"] as? Bool ?? true
 
       // Get lensFacing parameter
@@ -102,6 +103,7 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
         frame: frame,
         modelPathOrName: modelName,
         task: task,
+        useGpu: useGpu,
         cameraPosition: cameraPosition
       )
 
@@ -384,9 +386,10 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
           let taskString = args["task"] as? String
         {
           let task = YOLOTask.fromString(taskString)
+          let useGpu = args["useGpu"] as? Bool ?? true
 
           // Use YOLOView's setModel method to switch the model
-          self.yoloView?.setModel(modelPathOrName: modelPath, task: task) { modelResult in
+          self.yoloView?.setModel(modelPathOrName: modelPath, task: task, useGpu: useGpu) { modelResult in
             switch modelResult {
             case .success:
 

--- a/ios/Classes/SwiftYOLOPlatformView.swift
+++ b/ios/Classes/SwiftYOLOPlatformView.swift
@@ -389,7 +389,8 @@ public class SwiftYOLOPlatformView: NSObject, FlutterPlatformView, FlutterStream
           let useGpu = args["useGpu"] as? Bool ?? true
 
           // Use YOLOView's setModel method to switch the model
-          self.yoloView?.setModel(modelPathOrName: modelPath, task: task, useGpu: useGpu) { modelResult in
+          self.yoloView?.setModel(modelPathOrName: modelPath, task: task, useGpu: useGpu) {
+            modelResult in
             switch modelResult {
             case .success:
 

--- a/ios/Classes/YOLOPlugin.swift
+++ b/ios/Classes/YOLOPlugin.swift
@@ -412,6 +412,7 @@ public class YOLOPlugin: NSObject, FlutterPlugin {
         }
 
         let task = YOLOTask.fromString(taskString)
+        let useGpu = args["useGpu"] as? Bool ?? true
 
         // Handle both String viewId (from Flutter) and Int viewId
         var viewIdInt: Int?
@@ -449,7 +450,7 @@ public class YOLOPlugin: NSObject, FlutterPlugin {
 
         // Get the YOLOView instance from the factory
         if let yoloView = SwiftYOLOPlatformViewFactory.getYOLOView(for: viewIdInt!) {
-          yoloView.setModel(modelPathOrName: modelPath, task: task) { modelResult in
+          yoloView.setModel(modelPathOrName: modelPath, task: task, useGpu: useGpu) { modelResult in
             switch modelResult {
             case .success:
               result(nil)  // Success

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -362,7 +362,8 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       }
 
     default:
-      ObjectDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
+      ObjectDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu)
+      {
         [weak self] result in
         switch result {
         case .success(let predictor):

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -200,11 +200,12 @@ public class YOLOView: UIView, VideoCaptureDelegate {
     frame: CGRect,
     modelPathOrName: String,
     task: YOLOTask,
+    useGpu: Bool = true,
     cameraPosition: AVCaptureDevice.Position = .back
   ) {
     self.videoCapture = VideoCapture()
     super.init(frame: frame)
-    setModel(modelPathOrName: modelPathOrName, task: task)
+    setModel(modelPathOrName: modelPathOrName, task: task, useGpu: useGpu)
     setUpOrientationChangeNotification()
     self.setUpBoundingBoxViews()
     self.setupUI()
@@ -237,6 +238,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
   public func setModel(
     modelPathOrName: String,
     task: YOLOTask,
+    useGpu: Bool = true,
     completion: ((Result<Void, Error>) -> Void)? = nil
   ) {
     activityIndicator.startAnimating()
@@ -314,7 +316,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
 
     switch task {
     case .classify:
-      Classifier.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true) {
+      Classifier.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
         [weak self] result in
         switch result {
         case .success(let predictor):
@@ -325,7 +327,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       }
 
     case .segment:
-      Segmenter.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true) {
+      Segmenter.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
         [weak self] result in
         switch result {
         case .success(let predictor):
@@ -336,7 +338,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       }
 
     case .pose:
-      PoseEstimater.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true) {
+      PoseEstimater.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
         [weak self] result in
         switch result {
         case .success(let predictor):
@@ -347,7 +349,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       }
 
     case .obb:
-      ObbDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true) {
+      ObbDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
         [weak self] result in
         switch result {
         case .success(let predictor):
@@ -360,7 +362,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       }
 
     default:
-      ObjectDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true) {
+      ObjectDetector.create(unwrappedModelURL: unwrappedModelURL, isRealTime: true, useGpu: useGpu) {
         [weak self] result in
         switch result {
         case .success(let predictor):


### PR DESCRIPTION
## Summary
- honor `useGpu` in the iOS `YOLOView` camera path
- make `useGpu: false` avoid CoreML GPU while still using Neural Engine on iOS 16+
- update the `useGpu` docs to describe the non-GPU path accurately

Fixes #446

## Tests
- `flutter analyze`
- `flutter test`
- `flutter build ios --no-codesign` from `example/`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves iOS GPU control in the Flutter app by properly passing the `useGpu` setting through the app and using a more flexible non-GPU fallback for better stability and performance 🚀📱

### 📊 Key Changes
- Added full iOS support for the `useGpu` option when creating or switching YOLO models in the Flutter app ✅
- Passed `useGpu` from Flutter platform view and plugin layers down into `YOLOView` and all predictor creation paths 🔄
- Updated all iOS task types to respect the setting, including:
  - classification
  - segmentation
  - pose
  - OBB
  - object detection 🧠
- Changed the iOS fallback behavior when `useGpu: false`:
  - on iOS 16+, it now uses CPU + Neural Engine instead of CPU-only
  - on older iOS versions, it still uses CPU-only ⚙️
- Clarified documentation to explain that disabling GPU avoids unstable GPU paths rather than always forcing pure CPU execution 📝

### 🎯 Purpose & Impact
- Makes the `useGpu` setting actually work consistently across iOS model loading and model switching 🎯
- Improves stability on devices where the GPU path may be unreliable, while still keeping hardware acceleration when possible 🔒
- Can deliver better performance than the old CPU-only fallback on newer iPhones and iPads thanks to Neural Engine support ⚡
- Gives developers clearer, more predictable control over inference behavior in real-time apps 📲
- Reduces confusion in docs by aligning the wording with the actual runtime behavior 🙌