### PR TITLE
Padding fix for Android if using 3-button navigation mode

### DIFF
--- a/example/lib/presentation/controllers/camera_inference_controller.dart
+++ b/example/lib/presentation/controllers/camera_inference_controller.dart
@@ -100,10 +100,8 @@ class CameraInferenceController extends ChangeNotifier {
 
   void toggleSlider(SliderType type) {
     if (_isDisposed) return;
-    if (_activeSlider != type) {
-      _activeSlider = _activeSlider == type ? SliderType.none : type;
-      notifyListeners();
-    }
+    _activeSlider = _activeSlider == type ? SliderType.none : type;
+    notifyListeners();
   }
 
   void updateSliderValue(double value) {

--- a/example/lib/presentation/widgets/camera_controls.dart
+++ b/example/lib/presentation/widgets/camera_controls.dart
@@ -27,10 +27,12 @@ class CameraControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+
     return Stack(
       children: [
         Positioned(
-          bottom: isLandscape ? 16 : 32,
+          bottom: (isLandscape ? 16 : 32) + bottomInset,
           right: isLandscape ? 8 : 16,
           child: Column(
             children: [
@@ -66,7 +68,7 @@ class CameraControls extends StatelessWidget {
         ),
 
         Positioned(
-          bottom: MediaQuery.of(context).padding.top + (isLandscape ? 32 : 16),
+          bottom: MediaQuery.of(context).padding.top + (isLandscape ? 32 : 16) + bottomInset,
           left: isLandscape ? 32 : 16,
           child: CircleAvatar(
             radius: isLandscape ? 20 : 24,

--- a/example/lib/presentation/widgets/camera_controls.dart
+++ b/example/lib/presentation/widgets/camera_controls.dart
@@ -27,13 +27,13 @@ class CameraControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+    final viewPadding = MediaQuery.of(context).viewPadding;
 
     return Stack(
       children: [
         Positioned(
-          bottom: (isLandscape ? 16 : 32) + bottomInset,
-          right: isLandscape ? 8 : 16,
+          bottom: (isLandscape ? 16 : 32) + viewPadding.bottom,
+          right: (isLandscape ? 8 : 16) + (isLandscape ? viewPadding.right : 0),
           child: Column(
             children: [
               if (!isFrontCamera)
@@ -68,8 +68,11 @@ class CameraControls extends StatelessWidget {
         ),
 
         Positioned(
-          bottom: MediaQuery.of(context).padding.top + (isLandscape ? 32 : 16) + bottomInset,
-          left: isLandscape ? 32 : 16,
+          bottom:
+              MediaQuery.of(context).padding.top +
+              (isLandscape ? 32 : 16) +
+              viewPadding.bottom,
+          left: (isLandscape ? 32 : 16) + (isLandscape ? viewPadding.left : 0),
           child: CircleAvatar(
             radius: isLandscape ? 20 : 24,
             backgroundColor: Colors.black.withValues(alpha: 0.5),

--- a/example/lib/presentation/widgets/threshold_slider.dart
+++ b/example/lib/presentation/widgets/threshold_slider.dart
@@ -28,14 +28,18 @@ class ThresholdSlider extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+
     return Positioned(
       left: 0,
       right: 0,
       bottom: 0,
       child: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: isLandscape ? 16 : 24,
-          vertical: isLandscape ? 8 : 12,
+        padding: EdgeInsets.only(
+          left: isLandscape ? 16 : 24,
+          right: isLandscape ? 16 : 24,
+          top: isLandscape ? 8 : 12,
+          bottom: (isLandscape ? 8 : 12) + bottomInset,
         ),
         color: Colors.black.withValues(alpha: 0.8),
         child: SliderTheme(

--- a/example/lib/presentation/widgets/threshold_slider.dart
+++ b/example/lib/presentation/widgets/threshold_slider.dart
@@ -28,7 +28,8 @@ class ThresholdSlider extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+    final viewPadding = MediaQuery.of(context).viewPadding;
+    final horizontalInset = isLandscape ? viewPadding : EdgeInsets.zero;
 
     return Positioned(
       left: 0,
@@ -36,10 +37,10 @@ class ThresholdSlider extends StatelessWidget {
       bottom: 0,
       child: Container(
         padding: EdgeInsets.only(
-          left: isLandscape ? 16 : 24,
-          right: isLandscape ? 16 : 24,
+          left: (isLandscape ? 16 : 24) + horizontalInset.left,
+          right: (isLandscape ? 16 : 24) + horizontalInset.right,
           top: isLandscape ? 8 : 12,
-          bottom: (isLandscape ? 8 : 12) + bottomInset,
+          bottom: (isLandscape ? 8 : 12) + viewPadding.bottom,
         ),
         color: Colors.black.withValues(alpha: 0.8),
         child: SliderTheme(


### PR DESCRIPTION
If using 3-button navigation on Android the camera controls and threshold sliders appear underneath it. This PR adds safe-area handling so controls appear above/inside the system navigation area. Gesture navigation mode should remain unchanged.

It also fixes an issue where you can't seem to close the threshold slider once you've opened it.

Before:
<img width="429" height="934" alt="image" src="https://github.com/user-attachments/assets/a5307ee2-4046-41bc-aacc-06b06fe69c0b" />

After:
<img width="428" height="936" alt="image" src="https://github.com/user-attachments/assets/71d1fb48-4595-4c5f-a181-f7af2ff46a77" />

I have read the CLA Document and I sign the CLA

## PR Summary

### Summary
Fixes Android 3-button navigation overlap in the example camera UI and restores threshold-slider toggle behavior.

### Key Changes
- Uses `MediaQuery.viewPadding` to offset camera controls above bottom system navigation in portrait.
- Applies landscape left/right system insets so side-mounted Android navigation bars do not overlap the control column or slider touch area.
- Keeps the threshold slider clear of bottom insets while adding horizontal inset padding only in landscape.
- Simplifies `toggleSlider()` so tapping the active control closes the slider and tapping another control switches directly.

### Validation
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` from `example/`
