### PR TITLE
Fix FPS always showing 0.0 on iOS

### DIFF
--- a/ios/Classes/BasePredictor.swift
+++ b/ios/Classes/BasePredictor.swift
@@ -69,7 +69,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   var t3 = CACurrentMediaTime()  // FPS start
 
   /// Smoothed frames per second measurement (averaged over recent frames).
-  var t4 = 0.0  // FPS dt smoothed
+  var t4 = 1.0  // FPS dt smoothed (init to 1 to avoid initial division by zero)
 
   /// Flag indicating whether the predictor is currently processing an update.
   public var isUpdating: Bool = false

--- a/ios/Classes/BasePredictor.swift
+++ b/ios/Classes/BasePredictor.swift
@@ -69,7 +69,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   var t3 = CACurrentMediaTime()  // FPS start
 
   /// Smoothed frames per second measurement (averaged over recent frames).
-  var t4 = 1.0  // FPS dt smoothed (init to 1 to avoid initial division by zero)
+  var t4 = 0.0  // FPS dt smoothed
 
   /// Flag indicating whether the predictor is currently processing an update.
   public var isUpdating: Bool = false
@@ -292,6 +292,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
       // Invoke a VNRequestHandler with that image
       let handler = VNImageRequestHandler(
         cvPixelBuffer: pixelBuffer, orientation: imageOrientation, options: [:])
+      self.originalImageData = originalImageData
       t0 = CACurrentMediaTime()  // inference start
       do {
         if let request = visionRequest {
@@ -302,11 +303,30 @@ public class BasePredictor: Predictor, @unchecked Sendable {
       }
       t1 = CACurrentMediaTime() - t0  // inference dt
 
-      // Store original image data for result creation
-      self.originalImageData = originalImageData
-
       currentBuffer = nil
     }
+  }
+
+  /// Updates inference and FPS timing with the current frame measurements.
+  @discardableResult
+  func updateTiming() -> (speed: Double, fps: Double) {
+    let now = CACurrentMediaTime()
+    let inferenceTime = t0 > 0 ? now - t0 : t1
+    t1 = inferenceTime
+
+    if inferenceTime < 10.0 {
+      t2 = t2 == 0 ? inferenceTime : inferenceTime * 0.05 + t2 * 0.95
+    }
+
+    let frameInterval = now - t3
+    if frameInterval > 0, frameInterval < 10.0 {
+      t4 = t4 == 0 ? frameInterval : frameInterval * 0.05 + t4 * 0.95
+    }
+    t3 = now
+
+    let fps = t4 > 0 ? 1 / t4 : 0
+    currentOnInferenceTimeListener?.on(inferenceTime: t2 * 1000, fpsRate: fps)
+    return (speed: t2, fps: fps)
   }
 
   /// The confidence threshold for filtering detection results (default: 0.25).

--- a/ios/Classes/Classifier.swift
+++ b/ios/Classes/Classifier.swift
@@ -98,17 +98,9 @@ class Classifier: BasePredictor {
       probs = Probs(top1Label: top1, top5Labels: top5, top1Conf: top1Conf, top5Confs: top5Confs)
     }
 
-    // Measure FPS
-    if self.t1 < 10.0 {  // valid dt
-      self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-    }
-    self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-    self.t3 = CACurrentMediaTime()
-
-    self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)  // t2 seconds to ms
-    //                self.currentOnFpsRateListener?.on(fpsRate: 1 / self.t4)
+    let timing = updateTiming()
     var result = YOLOResult(
-      orig_shape: inputSize, boxes: [], probs: probs, speed: self.t2, fps: 1 / self.t4,
+      orig_shape: inputSize, boxes: [], probs: probs, speed: timing.speed, fps: timing.fps,
       names: labels)
 
     if let originalImageData = self.originalImageData {

--- a/ios/Classes/ObbDetector.swift
+++ b/ios/Classes/ObbDetector.swift
@@ -55,8 +55,10 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
           obbResults.append(obbResult)
         }
 
+        self.updateTime()
+
         var result = YOLOResult(
-          orig_shape: inputSize, boxes: [], obb: obbResults, speed: 0, names: labels)
+          orig_shape: inputSize, boxes: [], obb: obbResults, speed: self.t2, fps: 1 / self.t4, names: labels)
 
         // Add original image data if available
         if let originalImageData = self.originalImageData {
@@ -65,7 +67,6 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
         }
 
         self.currentOnResultsListener?.on(result: result)
-        self.updateTime()
       }
     }
   }

--- a/ios/Classes/ObbDetector.swift
+++ b/ios/Classes/ObbDetector.swift
@@ -55,10 +55,10 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
           obbResults.append(obbResult)
         }
 
-        self.updateTime()
+        let timing = updateTiming()
 
         var result = YOLOResult(
-          orig_shape: inputSize, boxes: [], obb: obbResults, speed: self.t2, fps: 1 / self.t4, names: labels)
+          orig_shape: inputSize, boxes: [], obb: obbResults, speed: timing.speed, fps: timing.fps, names: labels)
 
         // Add original image data if available
         if let originalImageData = self.originalImageData {
@@ -69,17 +69,6 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
         self.currentOnResultsListener?.on(result: result)
       }
     }
-  }
-
-  private func updateTime() {
-    if self.t1 < 10.0 {  // valid dt
-      self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-    }
-    self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-    self.t3 = CACurrentMediaTime()
-
-    self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)  // t2 seconds to ms
-
   }
 
   override func predictOnImage(image: CIImage) -> YOLOResult {
@@ -114,10 +103,10 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
             obbResults.append(obbResult)
           }
           let annotatedImage = drawOBBsOnCIImage(ciImage: image, obbDetections: obbResults)
-          updateTime()
+          let timing = updateTiming()
           return YOLOResult(
             orig_shape: inputSize, boxes: [], masks: nil, probs: nil, keypointsList: [],
-            obb: obbResults, annotatedImage: annotatedImage, speed: self.t2, fps: 1 / self.t4,
+            obb: obbResults, annotatedImage: annotatedImage, speed: timing.speed, fps: timing.fps,
             originalImage: nil, names: labels)
         }
       }

--- a/ios/Classes/ObjectDetector.swift
+++ b/ios/Classes/ObjectDetector.swift
@@ -86,17 +86,9 @@ class ObjectDetector: BasePredictor {
         boxes.append(box)
       }
 
-      // Measure FPS
-      if self.t1 < 10.0 {  // valid dt
-        self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-      }
-      self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-      self.t3 = CACurrentMediaTime()
-
-      self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)  // t2 seconds to ms
-      //                self.currentOnFpsRateListener?.on(fpsRate: 1 / self.t4)
+      let timing = updateTiming()
       var result = YOLOResult(
-        orig_shape: inputSize, boxes: boxes, speed: self.t2, fps: 1 / self.t4, names: labels)
+        orig_shape: inputSize, boxes: boxes, speed: timing.speed, fps: timing.fps, names: labels)
 
       if let originalImageData = self.originalImageData {
         result.originalImage = UIImage(data: originalImageData)

--- a/ios/Classes/PoseEstimater.swift
+++ b/ios/Classes/PoseEstimater.swift
@@ -52,9 +52,11 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
           boxes.append(person.box)
           keypointsList.append(person.keypoints)
         }
+        self.updateTime()
+
         var result = YOLOResult(
           orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
-          annotatedImage: nil, speed: 0, fps: 0, originalImage: nil, names: labels)
+          annotatedImage: nil, speed: self.t2, fps: 1 / self.t4, originalImage: nil, names: labels)
 
         if let originalImageData = self.originalImageData {
           result.originalImage = UIImage(data: originalImageData)
@@ -62,7 +64,6 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
         }
 
         self.currentOnResultsListener?.on(result: result)
-        self.updateTime()
       }
     }
   }

--- a/ios/Classes/PoseEstimater.swift
+++ b/ios/Classes/PoseEstimater.swift
@@ -52,11 +52,11 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
           boxes.append(person.box)
           keypointsList.append(person.keypoints)
         }
-        self.updateTime()
+        let timing = updateTiming()
 
         var result = YOLOResult(
           orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
-          annotatedImage: nil, speed: self.t2, fps: 1 / self.t4, originalImage: nil, names: labels)
+          annotatedImage: nil, speed: timing.speed, fps: timing.fps, originalImage: nil, names: labels)
 
         if let originalImageData = self.originalImageData {
           result.originalImage = UIImage(data: originalImageData)
@@ -66,17 +66,6 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
         self.currentOnResultsListener?.on(result: result)
       }
     }
-  }
-
-  private func updateTime() {
-    if self.t1 < 10.0 {  // valid dt
-      self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-    }
-    self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-    self.t3 = CACurrentMediaTime()
-
-    self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)  // t2 seconds to ms
-
   }
 
   override func predictOnImage(image: CIImage) -> YOLOResult {
@@ -120,11 +109,11 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
           let annotatedImage = drawPoseOnCIImage(
             ciImage: image, keypointsList: keypointsForImage, confsList: confsList,
             boundingBoxes: boxes, originalImageSize: inputSize)
-          updateTime()
+          let timing = updateTiming()
           return YOLOResult(
             orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil,
-            keypointsList: keypointsList, annotatedImage: annotatedImage, speed: self.t2,
-            fps: 1 / self.t4, originalImage: nil, names: labels)
+            keypointsList: keypointsList, annotatedImage: annotatedImage, speed: timing.speed,
+            fps: timing.fps, originalImage: nil, names: labels)
         }
       }
     } catch {

--- a/ios/Classes/Segmenter.swift
+++ b/ios/Classes/Segmenter.swift
@@ -92,6 +92,9 @@ class Segmenter: BasePredictor, @unchecked Sendable {
           return
         }
         var maskResults = Masks(masks: processedMasks.1, combinedMask: processedMasks.0)
+
+        self.updateTime()
+
         var result = YOLOResult(
           orig_shape: self.inputSize, boxes: boxes, masks: maskResults, speed: self.t2,
           fps: 1 / self.t4, names: self.labels)
@@ -101,7 +104,6 @@ class Segmenter: BasePredictor, @unchecked Sendable {
 
         }
 
-        self.updateTime()
         self.currentOnResultsListener?.on(result: result)
       }
     }

--- a/ios/Classes/Segmenter.swift
+++ b/ios/Classes/Segmenter.swift
@@ -93,11 +93,11 @@ class Segmenter: BasePredictor, @unchecked Sendable {
         }
         var maskResults = Masks(masks: processedMasks.1, combinedMask: processedMasks.0)
 
-        self.updateTime()
+        let timing = self.updateTiming()
 
         var result = YOLOResult(
-          orig_shape: self.inputSize, boxes: boxes, masks: maskResults, speed: self.t2,
-          fps: 1 / self.t4, names: self.labels)
+          orig_shape: self.inputSize, boxes: boxes, masks: maskResults, speed: timing.speed,
+          fps: timing.fps, names: self.labels)
 
         if let originalImageData = self.originalImageData {
           result.originalImage = UIImage(data: originalImageData)
@@ -107,17 +107,6 @@ class Segmenter: BasePredictor, @unchecked Sendable {
         self.currentOnResultsListener?.on(result: result)
       }
     }
-  }
-
-  private func updateTime() {
-    if self.t1 < 10.0 {  // valid dt
-      self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-    }
-    self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-    self.t3 = CACurrentMediaTime()
-
-    self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)  // t2 seconds to ms
-
   }
 
   override func predictOnImage(image: CIImage) -> YOLOResult {
@@ -197,14 +186,10 @@ class Segmenter: BasePredictor, @unchecked Sendable {
         var annotatedImage = composeImageWithMask(
           baseImage: cgImage, maskImage: processedMasks.0!)
         var maskResults: Masks = Masks(masks: processedMasks.1, combinedMask: processedMasks.0)
-        if self.t1 < 10.0 {  // valid dt
-          self.t2 = self.t1 * 0.05 + self.t2 * 0.95  // smoothed inference time
-        }
-        self.t4 = (CACurrentMediaTime() - self.t3) * 0.05 + self.t4 * 0.95  // smoothed delivered FPS
-        self.t3 = CACurrentMediaTime()
+        let timing = updateTiming()
         result = YOLOResult(
           orig_shape: inputSize, boxes: boxes, masks: maskResults, annotatedImage: annotatedImage,
-          speed: self.t2, fps: 1 / self.t4, names: labels)
+          speed: timing.speed, fps: timing.fps, names: labels)
         annotatedImage = drawYOLODetections(on: CIImage(image: annotatedImage!)!, result: result)
         result.annotatedImage = annotatedImage
         return result

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -130,11 +130,6 @@ public class YOLOView: UIView, VideoCaptureDelegate {
   private var busy = false
   private var currentBuffer: CVPixelBuffer?
   var framesDone = 0
-  var t0 = 0.0  // inference start
-  var t1 = 0.0  // inference dt
-  var t2 = 0.0  // inference dt smoothed
-  var t3 = CACurrentMediaTime()  // FPS start
-  var t4 = 0.0  // FPS dt smoothed
   var task = YOLOTask.detect
   var colors: [String: UIColor] = [:]
   var modelName: String = ""


### PR DESCRIPTION
This attempts to fix the FPS counter always showing as 0.0 on IOS.

I can't seem to get any of the example models to work* so I've only tested it with my own OBB model where the FPS now works.

\*The v0.3.0 release doesn't have any of the model assets in the release, so the downloads will always 404.

```static const String _latestReleaseBaseUrl = 'https://github.com/ultralytics/yolo-flutter-app/releases/latest/download';```

I tried hard-coding it to the assets from v0.2.0 (```static const String _latestReleaseBaseUrl = 'https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.2.0';```) which does fix the download issue but I didn't get any detections of any of the models on both Android or iOS, so maybe this is a different issue. The FPS counter will show 0.0 if the model fails to run.

I have read the CLA Document and I sign the CLA

## PR Summary

### Summary
Fixes iOS real-time FPS and processing-time reporting by updating timing before results are emitted and by removing duplicated timing state from the view layer.

### Key Changes
- Keeps the smoothed FPS interval initialized at `0.0` and seeds it from the first real frame interval instead of a fake one-second value.
- Adds a shared `BasePredictor.updateTiming()` helper that computes the current inference duration from `t0`, updates FPS safely, and returns the exact values used in callbacks.
- Uses that shared timing path across detection, classification, OBB, pose, and segmentation result emission.
- Preserves original image data before the Vision request runs so callback-created results still receive the current frame data.
- Removes duplicate timing helper implementations from task-specific predictors and duplicate timing state from `YOLOView`.

### Validation
- `flutter analyze`
- `flutter test`
- `flutter build ios --simulator --no-codesign` from `example/`
