### PR TITLE
Add Android wide back camera preference

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -64,7 +64,15 @@ class YOLOPlatformView(
 
         // Parse lensFacing parameter
         val lensFacingParam = creationParams?.get("lensFacing") as? String ?: "back"
-        val lensFacing = when (lensFacingParam.lowercase()) {
+        val lensFacingValue = lensFacingParam.lowercase()
+        val preferWideBackCamera = lensFacingValue in setOf(
+            "backwide",
+            "back_wide",
+            "wide",
+            "ultrawide",
+            "ultra_wide"
+        )
+        val lensFacing = when (lensFacingValue) {
             "front" -> androidx.camera.core.CameraSelector.LENS_FACING_FRONT
             else -> androidx.camera.core.CameraSelector.LENS_FACING_BACK
         }
@@ -78,7 +86,7 @@ class YOLOPlatformView(
         yoloView.setShowOverlays(showOverlaysParam)
 
         // Set lens facing before initializing camera
-        yoloView.setLensFacing(lensFacing)
+        yoloView.setLensFacing(lensFacing, preferWideBackCamera)
 
         // Configure YOLOView streaming functionality
         setupYOLOViewStreaming(creationParams)

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -65,13 +65,7 @@ class YOLOPlatformView(
         // Parse lensFacing parameter
         val lensFacingParam = creationParams?.get("lensFacing") as? String ?: "back"
         val lensFacingValue = lensFacingParam.lowercase()
-        val preferWideBackCamera = lensFacingValue in setOf(
-            "backwide",
-            "back_wide",
-            "wide",
-            "ultrawide",
-            "ultra_wide"
-        )
+        val preferWideBackCamera = lensFacingValue == "backwide"
         val lensFacing = when (lensFacingValue) {
             "front" -> androidx.camera.core.CameraSelector.LENS_FACING_FRONT
             else -> androidx.camera.core.CameraSelector.LENS_FACING_BACK

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -13,6 +13,8 @@ import android.view.*
 import android.widget.FrameLayout
 import android.widget.Toast
 import android.view.ScaleGestureDetector
+import android.hardware.camera2.CameraCharacteristics
+import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.*
 import androidx.camera.core.Camera
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -197,6 +199,7 @@ class YOLOView @JvmOverloads constructor(
 
     // Camera config
     private var lensFacing = CameraSelector.LENS_FACING_BACK
+    private var preferWideBackCamera = false
     private lateinit var cameraProviderFuture: ListenableFuture<ProcessCameraProvider>
     private var camera: Camera? = null
 
@@ -537,9 +540,7 @@ class YOLOView @JvmOverloads constructor(
                         onFrame(imageProxy)
                     }
 
-                    val cameraSelector = CameraSelector.Builder()
-                        .requireLensFacing(lensFacing)
-                        .build()
+                    val cameraSelector = buildCameraSelector(cameraProvider)
 
                     cameraProvider.unbindAll()
 
@@ -582,8 +583,46 @@ class YOLOView @JvmOverloads constructor(
         }
     }
 
-    fun setLensFacing(facing: Int) {
+    private fun buildCameraSelector(cameraProvider: ProcessCameraProvider): CameraSelector {
+        if (lensFacing != CameraSelector.LENS_FACING_BACK || !preferWideBackCamera) {
+            return CameraSelector.Builder()
+                .requireLensFacing(lensFacing)
+                .build()
+        }
+
+        return selectWidestBackCamera(cameraProvider)?.let { wideCamera ->
+            CameraSelector.Builder()
+                .addCameraFilter { cameraInfos ->
+                    cameraInfos.filter { it == wideCamera }
+                }
+                .build()
+        } ?: CameraSelector.DEFAULT_BACK_CAMERA
+    }
+
+    private fun selectWidestBackCamera(cameraProvider: ProcessCameraProvider): CameraInfo? {
+        return try {
+            cameraProvider.availableCameraInfos
+                .mapNotNull { cameraInfo ->
+                    val camera2Info = Camera2CameraInfo.from(cameraInfo)
+                    val facing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
+                    if (facing != CameraCharacteristics.LENS_FACING_BACK) return@mapNotNull null
+
+                    val focalLength = camera2Info
+                        .getCameraCharacteristic(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)
+                        ?.minOrNull() ?: return@mapNotNull null
+                    cameraInfo to focalLength
+                }
+                .minByOrNull { it.second }
+                ?.first
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to select wide back camera; using default back camera", e)
+            null
+        }
+    }
+
+    fun setLensFacing(facing: Int, preferWideBackCamera: Boolean = false) {
         lensFacing = facing
+        this.preferWideBackCamera = preferWideBackCamera && facing == CameraSelector.LENS_FACING_BACK
         // Restart camera if already started
         if (::cameraProviderFuture.isInitialized) {
             startCamera()
@@ -591,6 +630,7 @@ class YOLOView @JvmOverloads constructor(
     }
 
     fun switchCamera() {
+        preferWideBackCamera = false
         lensFacing = if (lensFacing == CameraSelector.LENS_FACING_BACK) {
             CameraSelector.LENS_FACING_FRONT
         } else {

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -600,9 +600,9 @@ class YOLOView @JvmOverloads constructor(
     }
 
     private fun selectWidestBackCamera(cameraProvider: ProcessCameraProvider): CameraInfo? {
-        return try {
-            cameraProvider.availableCameraInfos
-                .mapNotNull { cameraInfo ->
+        return cameraProvider.availableCameraInfos
+            .mapNotNull { cameraInfo ->
+                try {
                     val camera2Info = Camera2CameraInfo.from(cameraInfo)
                     val facing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
                     if (facing != CameraCharacteristics.LENS_FACING_BACK) return@mapNotNull null
@@ -611,13 +611,13 @@ class YOLOView @JvmOverloads constructor(
                         .getCameraCharacteristic(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)
                         ?.minOrNull() ?: return@mapNotNull null
                     cameraInfo to focalLength
+                } catch (e: Exception) {
+                    Log.w(TAG, "Skipping camera with unreadable metadata", e)
+                    null
                 }
-                .minByOrNull { it.second }
-                ?.first
-        } catch (e: Exception) {
-            Log.w(TAG, "Unable to select wide back camera; using default back camera", e)
-            null
-        }
+            }
+            .minByOrNull { it.second }
+            ?.first
     }
 
     fun setLensFacing(facing: Int, preferWideBackCamera: Boolean = false) {

--- a/doc/api.md
+++ b/doc/api.md
@@ -274,6 +274,10 @@ class YOLOView extends StatefulWidget {
 | `overlayTheme`         | `YOLOOverlayTheme`                  | ❌       | `const YOLOOverlayTheme()` | Customize Flutter overlay styling                 |
 | `lensFacing`           | `LensFacing`                        | ❌       | `LensFacing.back`          | Initial camera lens selection                     |
 
+`LensFacing.backWide` prefers the shortest-focal-length rear camera on Android
+and falls back to the default back camera when the device does not expose a
+wide rear lens. Other platforms treat it as `LensFacing.back`.
+
 #### Example
 
 ```dart

--- a/ios/Classes/ObbDetector.swift
+++ b/ios/Classes/ObbDetector.swift
@@ -58,7 +58,8 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
         let timing = updateTiming()
 
         var result = YOLOResult(
-          orig_shape: inputSize, boxes: [], obb: obbResults, speed: timing.speed, fps: timing.fps, names: labels)
+          orig_shape: inputSize, boxes: [], obb: obbResults, speed: timing.speed, fps: timing.fps,
+          names: labels)
 
         // Add original image data if available
         if let originalImageData = self.originalImageData {

--- a/ios/Classes/ObbDetector.swift
+++ b/ios/Classes/ObbDetector.swift
@@ -58,8 +58,7 @@ class ObbDetector: BasePredictor, @unchecked Sendable {
         let timing = updateTiming()
 
         var result = YOLOResult(
-          orig_shape: inputSize, boxes: [], obb: obbResults, speed: timing.speed, fps: timing.fps,
-          names: labels)
+          orig_shape: inputSize, boxes: [], obb: obbResults, speed: timing.speed, fps: timing.fps, names: labels)
 
         // Add original image data if available
         if let originalImageData = self.originalImageData {

--- a/ios/Classes/PoseEstimater.swift
+++ b/ios/Classes/PoseEstimater.swift
@@ -56,8 +56,7 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
 
         var result = YOLOResult(
           orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
-          annotatedImage: nil, speed: timing.speed, fps: timing.fps, originalImage: nil,
-          names: labels)
+          annotatedImage: nil, speed: timing.speed, fps: timing.fps, originalImage: nil, names: labels)
 
         if let originalImageData = self.originalImageData {
           result.originalImage = UIImage(data: originalImageData)

--- a/ios/Classes/PoseEstimater.swift
+++ b/ios/Classes/PoseEstimater.swift
@@ -56,7 +56,8 @@ class PoseEstimater: BasePredictor, @unchecked Sendable {
 
         var result = YOLOResult(
           orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
-          annotatedImage: nil, speed: timing.speed, fps: timing.fps, originalImage: nil, names: labels)
+          annotatedImage: nil, speed: timing.speed, fps: timing.fps, originalImage: nil,
+          names: labels)
 
         if let originalImageData = self.originalImageData {
           result.originalImage = UIImage(data: originalImageData)

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -15,8 +15,14 @@ import 'package:ultralytics_yolo/config/channel_config.dart';
 import 'package:ultralytics_yolo/widgets/yolo_controller.dart';
 import 'package:ultralytics_yolo/widgets/yolo_overlay.dart';
 
-/// Enum for camera lens facing direction
-enum LensFacing { back, front }
+/// Enum for camera lens selection.
+enum LensFacing {
+  back,
+  front,
+
+  /// Prefer the shortest-focal-length rear camera on Android, falling back to [back].
+  backWide,
+}
 
 /// A Flutter widget that displays a real-time camera preview with YOLO object detection.
 class YOLOView extends StatefulWidget {

--- a/test/yolo_view_test.dart
+++ b/test/yolo_view_test.dart
@@ -361,6 +361,15 @@ void main() {
         expect(widget.lensFacing, LensFacing.front);
       });
 
+      test('YOLOView accepts LensFacing.backWide', () {
+        const widget = YOLOView(
+          modelPath: 'test_model.tflite',
+          task: YOLOTask.detect,
+          lensFacing: LensFacing.backWide,
+        );
+        expect(widget.lensFacing, LensFacing.backWide);
+      });
+
       testWidgets('creates widget with front camera', (
         WidgetTester tester,
       ) async {
@@ -395,6 +404,24 @@ void main() {
         expect(find.byType(YOLOView), findsOneWidget);
         final yoloView = tester.widget<YOLOView>(find.byType(YOLOView));
         expect(yoloView.lensFacing, LensFacing.back);
+      });
+
+      testWidgets('creates widget with wide back camera preference', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: YOLOView(
+              modelPath: 'test_model.tflite',
+              task: YOLOTask.detect,
+              lensFacing: LensFacing.backWide,
+            ),
+          ),
+        );
+
+        expect(find.byType(YOLOView), findsOneWidget);
+        final yoloView = tester.widget<YOLOView>(find.byType(YOLOView));
+        expect(yoloView.lensFacing, LensFacing.backWide);
       });
 
       testWidgets('lensFacing parameter does not force widget recreation', (


### PR DESCRIPTION
## Summary
- add `LensFacing.backWide` for Android wide-angle camera selection
- make Android CameraX prefer the shortest-focal-length rear camera when requested, falling back to the default back camera when unavailable
- document the Android-only behavior and add widget coverage for the new enum value

Fixes #462

## Validation
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` from `example/`
- `flutter build ios --simulator --no-codesign` from `example/`
- `dart pub publish --dry-run`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new `LensFacing.backWide` camera option to the Flutter YOLO app, letting Android prefer the widest rear camera for a broader field of view 📷✨

### 📊 Key Changes
- Added a new Flutter camera enum option: `LensFacing.backWide` 🆕
- Updated Android camera setup to recognize `"backwide"` and pass a wide-camera preference into the native view
- Implemented Android logic to:
  - detect available rear cameras
  - inspect camera metadata
  - choose the rear camera with the shortest focal length, which is typically the widest lens 🔍
- Added fallback behavior so devices without a wide rear camera still use the normal back camera safely ✅
- Updated camera switching behavior so manual camera flips reset the wide-camera preference appropriately 🔄
- Documented the new API behavior in `doc/api.md`, including platform-specific behavior
- Added Flutter tests to verify `LensFacing.backWide` is accepted and works in widget creation tests 🧪
- Included minor iOS formatting-only changes with no functional impact

### 🎯 Purpose & Impact
- Gives developers an easy way to start with a wider rear camera view on Android, which can help capture more of a scene in real-time inference 🌍
- Improves flexibility for apps that benefit from a broader camera perspective, such as object detection in tight spaces or wide environments
- Keeps behavior backward-compatible by falling back to the standard back camera when a wide lens is unavailable 👍
- Limits platform risk: on non-Android platforms, `backWide` behaves like normal back camera selection, so cross-platform apps remain stable
- Improves developer experience with clearer API docs and test coverage, making the new feature easier to adopt and trust 🚀