### PR TITLE
Fix Android C++ runtime linkage

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -39,6 +39,6 @@ log
 
 target_link_libraries(
 ultralytics
+c++_shared
 ${log-lib}
 )
-


### PR DESCRIPTION
## Summary
- explicitly link the Android native plugin target against libc++ shared runtime
- ensures the generated NDK link command includes `-lc++_shared` for release builds

Fixes #480

## Testing
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` from `example/`
- `flutter build apk --release` from `example/`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds the shared C++ runtime library to Android native linking, improving build/runtime compatibility for the Flutter app’s native YOLO components 🤖📱

### 📊 Key Changes
- Updated Android native build config in `android/src/main/cpp/CMakeLists.txt`
- Added `c++_shared` to `target_link_libraries(...)`
- Kept existing Android log library linkage unchanged

### 🎯 Purpose & Impact
- Helps ensure the app’s native C++ code links against the correct shared C++ standard library 🔧
- Can prevent Android build, packaging, or runtime issues related to missing native C++ dependencies
- Improves stability and compatibility for devices using the app’s native inference components ✅
- This is a small but important infrastructure fix, with no expected changes to app features or user-facing behavior 👌