### PR TITLE
Prepare 0.3.2 pub release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- **Bug Fix**: Fix Android NDK C++ runtime linkage for release builds that failed with unresolved `std::__throw_length_error` symbols (#480, #481).
+
 ## 0.3.1
 
 - **Feature**: Add `LensFacing.backWide` on Android to prefer the shortest-focal-length rear camera and fall back to the default back camera when unavailable (#478).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.3.1
+  ultralytics_yolo: ^0.3.2
 ```
 
 ```bash

--- a/doc/install.md
+++ b/doc/install.md
@@ -18,7 +18,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 dependencies:
   flutter:
     sdk: flutter
-  ultralytics_yolo: ^0.3.1 # Latest version
+  ultralytics_yolo: ^0.3.2 # Latest version
 ```
 
 Run the installation command:

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -35,7 +35,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 dependencies:
   flutter:
     sdk: flutter
-  ultralytics_yolo: ^0.3.1
+  ultralytics_yolo: ^0.3.2
   image_picker: ^1.2.1 # For image selection
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary
- bump `ultralytics_yolo` to `0.3.2`
- add changelog entry for the Android NDK C++ runtime linkage fix
- update README and docs install snippets to `^0.3.2`

## Testing
- `flutter analyze`
- `flutter test`
- `dart pub publish --dry-run`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR releases `ultralytics_yolo` version `0.3.2`, mainly fixing an Android release-build issue caused by incorrect NDK C++ runtime linkage.

### 📊 Key Changes
- Fixed an Android native build bug that caused release builds to fail with unresolved `std::__throw_length_error` symbols ⚠️
- Updated the changelog to document the new `0.3.2` bug-fix release 📝
- Bumped the package version from `0.3.1` to `0.3.2` in `pubspec.yaml` 📦
- Updated README and install/quickstart docs to reference `ultralytics_yolo: ^0.3.2` ✅

### 🎯 Purpose & Impact
- Improves reliability for Flutter developers building Android apps with the Ultralytics YOLO plugin on release configurations 🚀
- Resolves a low-level native linking problem, reducing build failures and making production deployment smoother 🛠️
- Keeps documentation aligned with the latest package version, helping users install the correct release without confusion 📚
- This is a maintenance-focused update with no new features, but an important fix for teams shipping Android apps to users 🎯