### PR TITLE
Prepare 0.3.3 pub release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+- **Bug Fix**: Improve Android overlay alignment and bitmap cleanup, harden iOS image inference crash paths, and remove unused platform code (#484).
+
 ## 0.3.2
 
 - **Bug Fix**: Fix Android NDK C++ runtime linkage for release builds that failed with unresolved `std::__throw_length_error` symbols (#480, #481).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.3.2
+  ultralytics_yolo: ^0.3.3
 ```
 
 ```bash

--- a/doc/install.md
+++ b/doc/install.md
@@ -18,7 +18,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 dependencies:
   flutter:
     sdk: flutter
-  ultralytics_yolo: ^0.3.2 # Latest version
+  ultralytics_yolo: ^0.3.3 # Latest version
 ```
 
 Run the installation command:

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -35,7 +35,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 dependencies:
   flutter:
     sdk: flutter
-  ultralytics_yolo: ^0.3.2
+  ultralytics_yolo: ^0.3.3
   image_picker: ^1.2.1 # For image selection
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary
- Bump `ultralytics_yolo` to `0.3.3`.
- Add a `0.3.3` changelog entry for the post-`0.3.2` platform fixes in #484.
- Update README, install, and quickstart dependency snippets to `^0.3.3`.

## Test plan
- [x] `dart pub publish --dry-run` — 0 warnings

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR releases `ultralytics_yolo` version **0.3.3**, focused on bug fixes for Android and iOS stability, plus documentation and package version updates.

### 📊 Key Changes
- 🏷️ Bumped the package version from **0.3.2** to **0.3.3** in `pubspec.yaml`.
- 📝 Updated the **README** and install/quickstart docs to reference `ultralytics_yolo: ^0.3.3`.
- 📘 Added a **0.3.3 changelog entry** describing the main fixes:
  - 🤖 Improved **Android overlay alignment**
  - 🧹 Improved **bitmap cleanup** on Android
  - 🍎 Hardened **iOS image inference crash paths**
  - 🗑️ Removed **unused platform code**

### 🎯 Purpose & Impact
- ✅ Makes the Flutter YOLO plugin more **stable and reliable** across Android and iOS.
- 🎯 Improves **visual accuracy** on Android by better aligning overlays with detections.
- 💾 Reduces the chance of **memory/resource issues** through better bitmap cleanup.
- 🛡️ Lowers the risk of **iOS crashes** during image inference, improving app robustness.
- 📦 Gives users a clear upgrade path to **version 0.3.3** with updated documentation and release notes.