### PR TITLE
Configure Android release signing

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.withInputStream { keystoreProperties.load(it) }
+}
+
 android {
     namespace = "com.ultralytics.yolo"
     compileSdk = flutter.compileSdkVersion
@@ -27,12 +33,18 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        release {
+            keyAlias = keystoreProperties["keyAlias"] ?: System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword = keystoreProperties["keyPassword"] ?: System.getenv("ANDROID_KEY_PASSWORD")
+            storeFile = keystoreProperties["storeFile"] ? rootProject.file(keystoreProperties["storeFile"]) : null
+            storePassword = keystoreProperties["storePassword"] ?: System.getenv("ANDROID_STORE_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
-            
-            // Add ProGuard rules
+            signingConfig = signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
## Summary
- configure the example Android release build to use an ignored upload keystore via key.properties or environment variables
- remove debug signing from release bundles

## Validation
- flutter build appbundle --release

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR adds proper Android release signing support to the Flutter example app, replacing debug-key signing with a real release signing configuration.

### 📊 Key Changes
- Added support for loading Android signing credentials from a `key.properties` file.
- Added a fallback to environment variables for signing values like:
  - `ANDROID_KEY_ALIAS`
  - `ANDROID_KEY_PASSWORD`
  - `ANDROID_STORE_PASSWORD`
- Introduced a dedicated `release` signing config in `example/android/app/build.gradle`.
- Updated the release build type to use `signingConfigs.release` instead of `signingConfigs.debug`.
- Kept ProGuard optimization enabled for release builds.

### 🎯 Purpose & Impact
- ✅ Makes the example app ready for proper production-style Android release builds.
- 🚀 Improves security by avoiding the use of debug signing keys for release builds.
- 🔄 Adds flexibility for local development and CI/CD pipelines by supporting both `key.properties` and environment variables.
- 📦 Helps developers prepare signed APKs/AABs for distribution to testers or app stores more easily.
- ⚠️ Users building release versions will now need to provide valid signing credentials; otherwise, release signing may fail.