### PR TITLE
Add app launch smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
   example-android:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6
@@ -68,6 +68,21 @@ jobs:
       - name: Build example Android app
         working-directory: example
         run: flutter build apk --debug
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Launch smoke test (Android emulator)
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          working-directory: example
+          script: flutter test integration_test/app_launch_test.dart
 
   example-ios:
     runs-on: macos-26
@@ -88,3 +103,14 @@ jobs:
       - name: Build example iOS app
         working-directory: example
         run: flutter build ios --simulator --no-codesign
+
+      - name: Boot iOS Simulator
+        run: |
+          UDID=$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/{print $2; exit}')
+          echo "Booting simulator $UDID"
+          xcrun simctl boot "$UDID"
+          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
+
+      - name: Launch smoke test (iOS Simulator)
+        working-directory: example
+        run: flutter test integration_test/app_launch_test.dart -d "$SIMULATOR_UDID"

--- a/example/integration_test/app_launch_test.dart
+++ b/example/integration_test/app_launch_test.dart
@@ -1,0 +1,42 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+// App launch / smoke test.
+//
+// Boots the real example application on a device or simulator and verifies it
+// reaches its first frame without crashing. Because it runs the full app it
+// exercises the native plugin registration and the YOLOView platform view —
+// i.e. it catches launch-time native regressions (e.g. a stale storyboard
+// module reference) that a host-only widget test cannot.
+//
+// Run with:  flutter test integration_test/app_launch_test.dart -d <device>
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:ultralytics_yolo_example/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('example app launches without crashing', (
+    WidgetTester tester,
+  ) async {
+    app.main();
+
+    // First frame.
+    await tester.pump();
+    // Let async launch work (platform view creation, permission requests, model
+    // resolution) kick off. Deliberately not pumpAndSettle: the camera screen
+    // drives a continuous frame/zoom stream that never settles.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 2));
+
+    // The app shell mounted.
+    expect(find.byType(MaterialApp), findsOneWidget);
+    // The initial route (real-time camera screen) built its scaffold.
+    expect(find.byType(Scaffold), findsWidgets);
+    // Nothing threw during launch.
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Adds an app launch / smoke test that boots the example app on an **iOS Simulator** and an **Android emulator** and verifies it reaches its first frame without crashing.

Because it runs the full app (not a host-only widget test), it exercises native plugin registration and the `YOLOView` platform view — so it catches launch-time native regressions such as a stale storyboard module reference, which a Dart-only test cannot.

### Changes
- `example/integration_test/app_launch_test.dart` — launches the real app via `main()`, pumps a few frames (no `pumpAndSettle`, since the camera screen streams continuously), and asserts the `MaterialApp`/`Scaffold` shell mounts and nothing throws during launch.
- `.github/workflows/ci.yml`:
  - `example-ios`: boot an iOS Simulator and run the test (`flutter test integration_test/app_launch_test.dart`).
  - `example-android`: enable KVM and run the test on an emulator via `reactivecircus/android-emulator-runner`.

Validated locally on an iPhone 17 Pro Simulator: builds, launches, and passes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✅ This PR strengthens CI by adding real app launch smoke tests for both Android and iOS, helping catch startup and native integration issues earlier.

### 📊 Key Changes
- Added a new Flutter integration test at `example/integration_test/app_launch_test.dart` 🚀
- The new test launches the actual example app and verifies it reaches its first screen without crashing
- The test specifically checks core app startup elements like `MaterialApp`, `Scaffold`, and confirms no launch-time exceptions occur
- Updated GitHub Actions CI for Android to:
  - increase timeout from 20 to 30 minutes ⏱️
  - enable KVM for faster emulator support
  - run the new smoke test on an Android emulator 🤖
- Updated GitHub Actions CI for iOS to:
  - boot an iPhone simulator automatically
  - run the same smoke test on iOS 🍎
- The smoke test is designed to catch native/plugin startup regressions that simpler widget-only tests may miss, including issues around plugin registration and platform views

### 🎯 Purpose & Impact
- Improves reliability by testing that the example app actually launches on real simulated devices before changes are merged 🛡️
- Helps detect platform-specific startup bugs earlier, especially native integration issues on Android and iOS
- Reduces the chance of broken releases caused by app launch failures or misconfigured native code
- Gives contributors and maintainers more confidence that the Flutter plugin and example app work end-to-end across both mobile platforms ✅
- May slightly increase CI runtime, but provides much stronger coverage of real-world app behavior 📈