### PR TITLE
Default showcase model size to nano on launch and task switch

### DIFF
--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -65,7 +65,6 @@ class YOLOShowcase extends StatefulWidget {
 
 class _YOLOShowcaseState extends State<YOLOShowcase> {
   static const _prefsTaskKey = 'ultralytics_yolo.showcase.task';
-  static const _prefsSizeKey = 'ultralytics_yolo.showcase.size';
 
   late YOLOViewController _controller;
   bool _ownsController = false;
@@ -208,18 +207,15 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
   Future<void> _bootstrap() async {
     final prefs = await SharedPreferences.getInstance();
     final storedTask = prefs.getString(_prefsTaskKey);
-    final storedSize = prefs.getString(_prefsSizeKey);
     if (mounted) {
       setState(() {
         if (storedTask != null) {
           final parsed = YOLOTaskParsing.tryParse(storedTask);
           if (parsed != null) _currentTask = parsed;
         }
-        if (storedSize != null && _allSizes.contains(storedSize)) {
-          _currentSize = storedSize;
-        }
-        // Clamp the restored size to whatever the resolver actually publishes for the active platform. Otherwise we'd
-        // hand `YOLOView` a `_currentModelId` that 404s on first launch before the chip even renders.
+        // The model size always starts at nano (matches the native iOS app) and is never restored from prefs.
+        // Clamp to whatever the resolver actually publishes for the active platform so we never hand `YOLOView`
+        // a `_currentModelId` that 404s on first launch before the chip even renders.
         _currentSize = _clampSizeToSupported(_currentSize, _currentTask);
       });
     }
@@ -336,11 +332,6 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
     await prefs.setString(_prefsTaskKey, task.name);
   }
 
-  Future<void> _persistSize(String size) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_prefsSizeKey, size);
-  }
-
   /// `YOLOView` confirms a model is actually loaded (initial load or a successful in-place switch). Record the loaded
   /// model's identity (not the possibly-already-changed optimistic selection) as the "running" baseline, so a later
   /// failed switch reverts to a model that truly loaded.
@@ -361,7 +352,6 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
         _runningTask = loadedTask;
         _runningSize = loadedSize;
         unawaited(_persistTask(loadedTask));
-        unawaited(_persistSize(loadedSize));
       }
     });
     _restoreInferenceAfterModelSwitch();
@@ -412,7 +402,9 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
   void _onTaskChanged(YOLOTask task) {
     if (task == _currentTask) return;
     HapticFeedback.selectionClick();
-    final targetSize = _clampSizeToSupported(_currentSize, task);
+    // Match the native iOS app: switching tasks always resets the model size to nano (the smallest/first size)
+    // rather than carrying over the previously selected size.
+    final targetSize = _clampSizeToSupported('n', task);
     YOLOModelManager.clearDownloadCancellation(
       _composeModelId(task: task, size: targetSize),
     );


### PR DESCRIPTION
Matches the native iOS app (`YOLOiOSApp`), which always loads the **nano** (smallest) model size at startup and resets to nano on every task switch via `reloadModelEntriesAndLoadFirst` + `setupSegmentedControl(preserveSelection: false)` (index 0). The Flutter `YOLOShowcase` previously *remembered* the size — preserving it across task switches and restoring it from `SharedPreferences` on launch.

### Changes (`lib/widgets/yolo_showcase.dart`)
- `_onTaskChanged`: reset the model size to nano (clamped to the supported set) instead of carrying over the current size.
- `_bootstrap`: no longer restores the model size from prefs — always starts at nano. Task restoration is unchanged.
- Remove the now-unused size persistence (`_persistSize` + size prefs key).

Explicit size taps still work; only the implicit default/switch behavior changes.

No version bump (stays 0.5.0). `flutter analyze` clean; 155 tests pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR simplifies model selection behavior in the Flutter showcase by always starting from the `nano` model size and no longer saving/restoring the previously selected size.

### 📊 Key Changes
- Removed persistence for the selected model size from shared preferences.
- Kept persistence for the selected task only, so the app still remembers whether users last used detection, segmentation, and similar tasks.
- Updated startup behavior so model size always begins at `nano` instead of restoring an older saved size.
- Added size clamping during boot to ensure the selected size is valid for the current platform and available models.
- Changed task switching behavior so moving to a new task always resets model size to `nano`.
- Removed the now-unused `_prefsSizeKey` and `_persistSize()` logic for cleaner state handling.
- Added comments clarifying that this behavior matches the native iOS app and helps avoid invalid model loading.

### 🎯 Purpose & Impact
- ✅ Makes behavior more consistent across platforms by matching the native iOS app’s default model-size handling.
- 🚫 Reduces the chance of startup failures or broken initial loads caused by restoring a model size that is not available on the current device or platform.
- 🧹 Simplifies the app’s state management by removing unnecessary saved preference logic.
- ⚡ Gives users a more predictable experience: switching tasks always starts from the smallest supported model, which is typically faster and safer to load.
- 🔧 Lowers the risk of 404-style model lookup issues during first launch or after task changes.