### PR TITLE
Add toggleTorch() and a torch button to the camera UI (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.1
+
+- **Feature**: Expose camera torch control on `YOLOViewController` with `toggleTorch()` and an `isTorchEnabled`
+  getter, and surface a torch toggle next to the zoom controls in `YOLOShowcase`.
+- **Enhancement**: Default the `YOLOShowcase` model size to nano on launch and when switching tasks, matching the
+  native iOS app's behavior.
+
 ## 0.5.0
 
 - **Enhancement**: Build the iOS plugin on the shared Ultralytics `YOLO` Swift package so the Flutter plugin and the

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -393,8 +393,8 @@ class YOLOPlatformView(
                 "setTorchMode" -> {
                     val enabled = call.argument<Boolean>("enabled")
                     if (enabled != null) {
-                        yoloView.setTorchMode(enabled)
-                        result.success(null)
+                        // Return the actual resulting torch state so Dart caches the real hardware state.
+                        result.success(yoloView.setTorchMode(enabled))
                     } else {
                         result.error("invalid_args", "enabled is required", null)
                     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -487,12 +487,16 @@ class YOLOView @JvmOverloads constructor(
         }
     }
 
-    fun setTorchMode(enabled: Boolean) {
+    // Turns the torch on/off and returns the actual resulting state (false when there is no flash unit), so callers
+    // can keep their cached state in sync with the hardware.
+    fun setTorchMode(enabled: Boolean): Boolean {
         camera?.let { cam ->
             if (cam.cameraInfo.hasFlashUnit()) {
                 cam.cameraControl.enableTorch(enabled)
+                return enabled
             }
         }
+        return false
     }
 
     // endregion

--- a/doc/api.md
+++ b/doc/api.md
@@ -374,13 +374,29 @@ Future<void> switchCamera()
 
 ##### `setTorchMode()`
 
-Turn the active camera torch on or off when supported.
+Turn the active camera torch (flashlight) on or off when supported. No-ops on cameras without a torch (e.g. most front cameras). Updates `isTorchEnabled`.
 
 ```dart
 Future<void> setTorchMode(bool enabled)
 ```
 
 **Parameters**: `enabled` - `true` to enable the torch, `false` to disable it
+
+##### `toggleTorch()`
+
+Toggle the active camera torch (flashlight) between on and off.
+
+```dart
+Future<void> toggleTorch()
+```
+
+##### `isTorchEnabled`
+
+Whether the torch is currently enabled, per the last `setTorchMode`/`toggleTorch` call.
+
+```dart
+bool get isTorchEnabled
+```
 
 ##### `switchModel()`
 

--- a/ios/Classes/SwiftYOLOPlatformView.swift
+++ b/ios/Classes/SwiftYOLOPlatformView.swift
@@ -298,8 +298,8 @@ public final class SwiftYOLOPlatformView: NSObject,
         if let args = call.arguments as? [String: Any],
           let enabled = args["enabled"] as? Bool
         {
-          self.yoloView?.setTorchMode(enabled)
-          result(nil)  // Success
+          // Return the actual resulting torch state so Dart caches the real hardware state.
+          result(self.yoloView?.setTorchMode(enabled) ?? false)
         } else {
           result(
             FlutterError(

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -1379,8 +1379,11 @@ public class YOLOView: UIView, VideoCaptureDelegate {
     }
   }
 
-  public func setTorchMode(_ enabled: Bool) {
-    guard let device = videoCapture.captureDevice, device.hasTorch else { return }
+  /// Turns the torch on/off and returns the actual resulting state (`false` when the active device has no torch or
+  /// configuration fails), so callers can keep their cached state in sync with the hardware.
+  @discardableResult
+  public func setTorchMode(_ enabled: Bool) -> Bool {
+    guard let device = videoCapture.captureDevice, device.hasTorch else { return false }
 
     do {
       try device.lockForConfiguration()
@@ -1393,8 +1396,10 @@ public class YOLOView: UIView, VideoCaptureDelegate {
       } else {
         device.torchMode = .off
       }
+      return device.torchMode == .on
     } catch {
       NSLog("YOLOView: Failed to set torch mode: %@", error.localizedDescription)
+      return false
     }
   }
 

--- a/lib/widgets/camera_toolbar.dart
+++ b/lib/widgets/camera_toolbar.dart
@@ -27,12 +27,6 @@ class CameraToolbar extends StatelessWidget {
   /// Fires on the camera-flip button.
   final VoidCallback onSwitchCamera;
 
-  /// Torch (flashlight) on/off state; controls the bolt icon.
-  final bool isTorchOn;
-
-  /// Fires on the torch toggle button.
-  final VoidCallback onToggleTorch;
-
   /// Fires on the share button (capture + system share / save).
   final VoidCallback onShare;
 
@@ -44,8 +38,6 @@ class CameraToolbar extends StatelessWidget {
     required this.isPaused,
     required this.onPlayPause,
     required this.onSwitchCamera,
-    required this.isTorchOn,
-    required this.onToggleTorch,
     required this.onShare,
     required this.onInfo,
   });
@@ -70,13 +62,6 @@ class CameraToolbar extends StatelessWidget {
               icon: CupertinoIcons.camera_rotate,
               onPressed: onSwitchCamera,
               semanticLabel: 'Switch camera',
-            ),
-            _ToolbarButton(
-              icon: isTorchOn
-                  ? CupertinoIcons.bolt_fill
-                  : CupertinoIcons.bolt_slash_fill,
-              onPressed: onToggleTorch,
-              semanticLabel: isTorchOn ? 'Turn torch off' : 'Turn torch on',
             ),
             _ToolbarButton(
               icon: CupertinoIcons.share,

--- a/lib/widgets/camera_toolbar.dart
+++ b/lib/widgets/camera_toolbar.dart
@@ -27,6 +27,12 @@ class CameraToolbar extends StatelessWidget {
   /// Fires on the camera-flip button.
   final VoidCallback onSwitchCamera;
 
+  /// Torch (flashlight) on/off state; controls the bolt icon.
+  final bool isTorchOn;
+
+  /// Fires on the torch toggle button.
+  final VoidCallback onToggleTorch;
+
   /// Fires on the share button (capture + system share / save).
   final VoidCallback onShare;
 
@@ -38,6 +44,8 @@ class CameraToolbar extends StatelessWidget {
     required this.isPaused,
     required this.onPlayPause,
     required this.onSwitchCamera,
+    required this.isTorchOn,
+    required this.onToggleTorch,
     required this.onShare,
     required this.onInfo,
   });
@@ -62,6 +70,13 @@ class CameraToolbar extends StatelessWidget {
               icon: CupertinoIcons.camera_rotate,
               onPressed: onSwitchCamera,
               semanticLabel: 'Switch camera',
+            ),
+            _ToolbarButton(
+              icon: isTorchOn
+                  ? CupertinoIcons.bolt_fill
+                  : CupertinoIcons.bolt_slash_fill,
+              onPressed: onToggleTorch,
+              semanticLabel: isTorchOn ? 'Turn torch off' : 'Turn torch on',
             ),
             _ToolbarButton(
               icon: CupertinoIcons.share,

--- a/lib/widgets/lens_picker.dart
+++ b/lib/widgets/lens_picker.dart
@@ -24,40 +24,65 @@ class LensPicker extends StatelessWidget {
   /// Invoked when the user taps a lens chip.
   final ValueChanged<LensInfo> onLensSelected;
 
+  /// Optional control rendered immediately to the right of the lens pill (e.g. a torch toggle), sharing the same
+  /// centered row so it sits directly next to the zoom options.
+  final Widget? trailing;
+
   const LensPicker({
     super.key,
     required this.lenses,
     required this.currentZoomFactor,
     required this.onLensSelected,
+    this.trailing,
   });
 
   @override
   Widget build(BuildContext context) {
-    if (lenses.isEmpty) return const SizedBox.shrink();
+    final pill = _pill(context);
+    if (pill == null && trailing == null) return const SizedBox.shrink();
+    if (trailing == null) return Center(child: pill);
+    if (pill == null) return Center(child: trailing);
+    // Keep the lens pill centered on screen: balance the trailing control (torch) on the right with an invisible
+    // copy of equal width on the left, so the zoom options stay centered while the torch sits directly next to them.
+    return Center(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Opacity(opacity: 0, child: IgnorePointer(child: trailing)),
+          const SizedBox(width: 6),
+          pill,
+          const SizedBox(width: 6),
+          trailing!,
+        ],
+      ),
+    );
+  }
+
+  /// The lens pill itself (single chip or sliding segmented control), un-centered; `null` when there are no lenses.
+  Widget? _pill(BuildContext context) {
+    if (lenses.isEmpty) return null;
     final selected = _closestLens(lenses, currentZoomFactor);
     if (lenses.length == 1) {
-      return Center(
-        child: Semantics(
-          button: true,
-          selected: true,
-          label: selected.label.isNotEmpty
-              ? selected.label
-              : '${_formatZoom(selected)}x zoom',
-          child: GestureDetector(
-            onTap: () => onLensSelected(selected),
-            child: Container(
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.38),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 9),
-              child: Text(
-                _formatZoom(selected),
-                style: const TextStyle(
-                  color: CupertinoColors.systemYellow,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                ),
+      return Semantics(
+        button: true,
+        selected: true,
+        label: selected.label.isNotEmpty
+            ? selected.label
+            : '${_formatZoom(selected)}x zoom',
+        child: GestureDetector(
+          onTap: () => onLensSelected(selected),
+          child: Container(
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.38),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 9),
+            child: Text(
+              _formatZoom(selected),
+              style: const TextStyle(
+                color: CupertinoColors.systemYellow,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
               ),
             ),
           ),
@@ -65,50 +90,48 @@ class LensPicker extends StatelessWidget {
       );
     }
 
-    // Content-hug + centered (NOT full-width) — a compact pill like the iOS app, not a screen-wide bar.
-    return Center(
-      child: CupertinoSlidingSegmentedControl<double>(
-        groupValue: selected.zoomFactor,
-        backgroundColor: Colors.black.withValues(alpha: 0.38),
-        thumbColor: Colors.white.withValues(alpha: 0.18),
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
-        onValueChanged: (zoom) {
-          if (zoom == null) return;
-          final picked = lenses.firstWhere(
-            (l) => l.zoomFactor == zoom,
-            orElse: () => selected,
-          );
-          onLensSelected(picked);
-        },
-        children: {
-          for (final lens in lenses)
-            lens.zoomFactor: Semantics(
-              // Name each chip for screen readers (the bare `0.5`/`1`/`2` glyphs are ambiguous out of context) and
-              // expose its selected state. Visuals are unchanged.
-              button: true,
-              selected: lens.zoomFactor == selected.zoomFactor,
-              label: lens.label.isNotEmpty
-                  ? lens.label
-                  : '${_formatZoom(lens)}x zoom',
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 6),
-                child: Text(
-                  _formatZoom(lens),
-                  style: TextStyle(
-                    // systemYellow when selected; white otherwise — matches the iOS reference exactly.
-                    color: lens.zoomFactor == selected.zoomFactor
-                        ? CupertinoColors.systemYellow
-                        : Colors.white,
-                    fontSize: 13,
-                    fontWeight: lens.zoomFactor == selected.zoomFactor
-                        ? FontWeight.w700
-                        : FontWeight.w600,
-                  ),
+    // Content-hug pill like the iOS app, not a screen-wide bar.
+    return CupertinoSlidingSegmentedControl<double>(
+      groupValue: selected.zoomFactor,
+      backgroundColor: Colors.black.withValues(alpha: 0.38),
+      thumbColor: Colors.white.withValues(alpha: 0.18),
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+      onValueChanged: (zoom) {
+        if (zoom == null) return;
+        final picked = lenses.firstWhere(
+          (l) => l.zoomFactor == zoom,
+          orElse: () => selected,
+        );
+        onLensSelected(picked);
+      },
+      children: {
+        for (final lens in lenses)
+          lens.zoomFactor: Semantics(
+            // Name each chip for screen readers (the bare `0.5`/`1`/`2` glyphs are ambiguous out of context) and
+            // expose its selected state. Visuals are unchanged.
+            button: true,
+            selected: lens.zoomFactor == selected.zoomFactor,
+            label: lens.label.isNotEmpty
+                ? lens.label
+                : '${_formatZoom(lens)}x zoom',
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Text(
+                _formatZoom(lens),
+                style: TextStyle(
+                  // systemYellow when selected; white otherwise — matches the iOS reference exactly.
+                  color: lens.zoomFactor == selected.zoomFactor
+                      ? CupertinoColors.systemYellow
+                      : Colors.white,
+                  fontSize: 13,
+                  fontWeight: lens.zoomFactor == selected.zoomFactor
+                      ? FontWeight.w700
+                      : FontWeight.w600,
                 ),
               ),
             ),
-        },
-      ),
+          ),
+      },
     );
   }
 

--- a/lib/widgets/yolo_controller.dart
+++ b/lib/widgets/yolo_controller.dart
@@ -36,6 +36,7 @@ class YOLOViewController {
   double _confidenceThreshold = 0.25;
   double _iouThreshold = 0.7;
   int _numItemsThreshold = 30;
+  bool _torchEnabled = false;
 
   final StreamController<double> _zoomController =
       StreamController<double>.broadcast();
@@ -48,6 +49,9 @@ class YOLOViewController {
   double get iouThreshold => _iouThreshold;
   int get numItemsThreshold => _numItemsThreshold;
   bool get isInitialized => _methodChannel != null && _viewId != null;
+
+  /// Whether the torch (flashlight) is currently enabled, per the last [setTorchMode]/[toggleTorch] call.
+  bool get isTorchEnabled => _torchEnabled;
 
   /// Emits the native zoom factor whenever it changes (e.g. via pinch).
   Stream<double> get zoomEvents => _zoomController.stream;
@@ -121,8 +125,15 @@ class YOLOViewController {
 
   Future<void> switchCamera() => _invoke('switchCamera');
 
-  Future<void> setTorchMode(bool enabled) =>
-      _invoke('setTorchMode', {'enabled': enabled});
+  /// Turns the active camera's torch (flashlight) on or off. No-ops on cameras without a torch
+  /// (e.g. most front cameras) and updates [isTorchEnabled].
+  Future<void> setTorchMode(bool enabled) async {
+    await _invoke('setTorchMode', {'enabled': enabled});
+    _torchEnabled = enabled;
+  }
+
+  /// Toggles the torch (flashlight) between on and off. See [setTorchMode] and [isTorchEnabled].
+  Future<void> toggleTorch() => setTorchMode(!_torchEnabled);
 
   Future<void> zoomIn() => _invoke('zoomIn');
 

--- a/lib/widgets/yolo_controller.dart
+++ b/lib/widgets/yolo_controller.dart
@@ -125,15 +125,20 @@ class YOLOViewController {
 
   Future<void> switchCamera() => _invoke('switchCamera');
 
-  /// Turns the active camera's torch (flashlight) on or off. No-ops on cameras without a torch
-  /// (e.g. most front cameras) and updates [isTorchEnabled].
+  /// Turns the active camera's torch (flashlight) on or off. The platform returns the actual resulting torch state,
+  /// which is cached in [isTorchEnabled] — so the cache stays correct even when the call fails or the active camera
+  /// has no torch (e.g. most front cameras). On a swallowed platform error the cached state is left unchanged.
   Future<void> setTorchMode(bool enabled) async {
-    await _invoke('setTorchMode', {'enabled': enabled});
-    _torchEnabled = enabled;
+    final result = await _invoke<bool>('setTorchMode', {'enabled': enabled});
+    if (result != null) _torchEnabled = result;
   }
 
   /// Toggles the torch (flashlight) between on and off. See [setTorchMode] and [isTorchEnabled].
   Future<void> toggleTorch() => setTorchMode(!_torchEnabled);
+
+  /// Resets the cached torch state to off without a platform call. Use after an operation where the platform drops
+  /// the torch on its own (e.g. switching the camera input), so [isTorchEnabled] stays in sync.
+  void resetTorchState() => _torchEnabled = false;
 
   Future<void> zoomIn() => _invoke('zoomIn');
 

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import 'dart:async';
+import 'package:flutter/cupertino.dart' show CupertinoIcons, CupertinoColors;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -1101,71 +1102,78 @@ class _ShowcaseOverlay extends StatelessWidget {
   }
 
   Widget _zoomLabel() {
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        ValueListenableBuilder<double>(
-          valueListenable: zoom,
-          builder: (context, z, _) => ValueListenableBuilder<String>(
-            valueListenable: lensLabel,
-            builder: (context, label, _) =>
-                ZoomIndicator(currentZoom: z, lensLabel: label),
-          ),
-        ),
-        // Torch state note, styled like the zoom HUD and sitting above the torch button on the right.
-        if (isTorchOn)
-          const Positioned(
-            right: 0,
-            bottom: 0,
-            child: Text(
-              'Torch on',
-              style: TextStyle(
-                color: Colors.amber,
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-      ],
+    return ValueListenableBuilder<double>(
+      valueListenable: zoom,
+      builder: (context, z, _) => ValueListenableBuilder<String>(
+        valueListenable: lensLabel,
+        builder: (context, label, _) =>
+            ZoomIndicator(currentZoom: z, lensLabel: label),
+      ),
     );
   }
 
   Widget _lensPicker() {
-    // Lens "camera tabs" stay centered; the torch toggle sits to their right.
-    return Stack(
-      alignment: Alignment.center,
+    return ValueListenableBuilder<double>(
+      valueListenable: zoom,
+      builder: (context, z, _) => LensPicker(
+        lenses: lenses,
+        currentZoomFactor: z,
+        onLensSelected: onLensSelected,
+        trailing: _torchControl(),
+      ),
+    );
+  }
+
+  /// Torch chip plus its "Torch on" note to the right. The note's space is reserved (shown/hidden in place) so
+  /// toggling the torch never shifts the chip or the centered zoom options.
+  Widget _torchControl() {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        ValueListenableBuilder<double>(
-          valueListenable: zoom,
-          builder: (context, z, _) => LensPicker(
-            lenses: lenses,
-            currentZoomFactor: z,
-            onLensSelected: onLensSelected,
-          ),
-        ),
-        Positioned(
-          right: 0,
-          child: Semantics(
-            button: true,
-            label: isTorchOn ? 'Turn torch off' : 'Turn torch on',
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: onToggleTorch,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 6,
-                ),
-                child: Icon(
-                  isTorchOn ? Icons.flashlight_on : Icons.flashlight_off,
-                  color: isTorchOn ? Colors.amber : Colors.white,
-                  size: 26,
-                ),
-              ),
+        _torchChip(),
+        const SizedBox(width: 6),
+        Visibility(
+          visible: isTorchOn,
+          maintainSize: true,
+          maintainAnimation: true,
+          maintainState: true,
+          child: const Text(
+            'Torch on',
+            style: TextStyle(
+              color: CupertinoColors.systemYellow,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
             ),
           ),
         ),
       ],
+    );
+  }
+
+  /// Torch toggle styled as a chip the same size as the lens (zoom) chips, sitting directly next to them. Uses the
+  /// native lightning glyph (Cupertino has no flashlight icon).
+  Widget _torchChip() {
+    return Semantics(
+      button: true,
+      label: isTorchOn ? 'Turn torch off' : 'Turn torch on',
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onToggleTorch,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.38),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Icon(
+            isTorchOn
+                ? CupertinoIcons.bolt_fill
+                : CupertinoIcons.bolt_slash_fill,
+            color: isTorchOn ? CupertinoColors.systemYellow : Colors.white,
+            size: 17,
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -1101,24 +1101,71 @@ class _ShowcaseOverlay extends StatelessWidget {
   }
 
   Widget _zoomLabel() {
-    return ValueListenableBuilder<double>(
-      valueListenable: zoom,
-      builder: (context, z, _) => ValueListenableBuilder<String>(
-        valueListenable: lensLabel,
-        builder: (context, label, _) =>
-            ZoomIndicator(currentZoom: z, lensLabel: label),
-      ),
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        ValueListenableBuilder<double>(
+          valueListenable: zoom,
+          builder: (context, z, _) => ValueListenableBuilder<String>(
+            valueListenable: lensLabel,
+            builder: (context, label, _) =>
+                ZoomIndicator(currentZoom: z, lensLabel: label),
+          ),
+        ),
+        // Torch state note, styled like the zoom HUD and sitting above the torch button on the right.
+        if (isTorchOn)
+          const Positioned(
+            right: 0,
+            bottom: 0,
+            child: Text(
+              'Torch on',
+              style: TextStyle(
+                color: Colors.amber,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+      ],
     );
   }
 
   Widget _lensPicker() {
-    return ValueListenableBuilder<double>(
-      valueListenable: zoom,
-      builder: (context, z, _) => LensPicker(
-        lenses: lenses,
-        currentZoomFactor: z,
-        onLensSelected: onLensSelected,
-      ),
+    // Lens "camera tabs" stay centered; the torch toggle sits to their right.
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        ValueListenableBuilder<double>(
+          valueListenable: zoom,
+          builder: (context, z, _) => LensPicker(
+            lenses: lenses,
+            currentZoomFactor: z,
+            onLensSelected: onLensSelected,
+          ),
+        ),
+        Positioned(
+          right: 0,
+          child: Semantics(
+            button: true,
+            label: isTorchOn ? 'Turn torch off' : 'Turn torch on',
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggleTorch,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                child: Icon(
+                  isTorchOn ? Icons.flashlight_on : Icons.flashlight_off,
+                  color: isTorchOn ? Colors.amber : Colors.white,
+                  size: 26,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -1137,8 +1184,6 @@ class _ShowcaseOverlay extends StatelessWidget {
       isPaused: isPaused,
       onPlayPause: onPlayPause,
       onSwitchCamera: onSwitchCamera,
-      isTorchOn: isTorchOn,
-      onToggleTorch: onToggleTorch,
       onShare: onShare,
       onInfo: onInfo,
     );

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -511,7 +511,9 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
     setState(() => _lenses = const [LensInfo(zoomFactor: 1, label: 'Camera')]);
     _zoom.value = 1;
     _lensLabel.value = '';
-    // Switching the camera input drops the torch (the new device may not have one); reflect that in the UI.
+    // Switching the camera input drops the torch (the new device may not have one); reset both the controller's
+    // cached state and the UI flag so they stay in sync across the switch.
+    _controller.resetTorchState();
     if (_torchOn) setState(() => _torchOn = false);
     await _controller.switchCamera();
     await Future<void>.delayed(const Duration(milliseconds: 300));

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -102,6 +102,7 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
   bool _isModelLoading = false;
 
   bool _isPaused = false;
+  bool _torchOn = false;
   Offset? _focusPosition;
   double _baseScale = 1;
   Size _viewSize = Size.zero;
@@ -509,9 +510,17 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
     setState(() => _lenses = const [LensInfo(zoomFactor: 1, label: 'Camera')]);
     _zoom.value = 1;
     _lensLabel.value = '';
+    // Switching the camera input drops the torch (the new device may not have one); reflect that in the UI.
+    if (_torchOn) setState(() => _torchOn = false);
     await _controller.switchCamera();
     await Future<void>.delayed(const Duration(milliseconds: 300));
     await _refreshLenses();
+  }
+
+  Future<void> _onToggleTorch() async {
+    HapticFeedback.selectionClick();
+    await _controller.toggleTorch();
+    if (mounted) setState(() => _torchOn = _controller.isTorchEnabled);
   }
 
   void _onPlayPause() {
@@ -715,6 +724,8 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
                   onLensSelected: _onLensSelected,
                   onPlayPause: _onPlayPause,
                   onSwitchCamera: () => unawaited(_onSwitchCamera()),
+                  isTorchOn: _torchOn,
+                  onToggleTorch: () => unawaited(_onToggleTorch()),
                   onShare: () => unawaited(_onShare()),
                   onInfo: () => _showInfoSheet(context),
                 ),
@@ -870,6 +881,8 @@ class _ShowcaseOverlay extends StatelessWidget {
     required this.onLensSelected,
     required this.onPlayPause,
     required this.onSwitchCamera,
+    required this.isTorchOn,
+    required this.onToggleTorch,
     required this.onShare,
     required this.onInfo,
   });
@@ -898,6 +911,8 @@ class _ShowcaseOverlay extends StatelessWidget {
   final ValueChanged<LensInfo> onLensSelected;
   final VoidCallback onPlayPause;
   final VoidCallback onSwitchCamera;
+  final bool isTorchOn;
+  final VoidCallback onToggleTorch;
   final VoidCallback onShare;
   final VoidCallback onInfo;
 
@@ -1122,6 +1137,8 @@ class _ShowcaseOverlay extends StatelessWidget {
       isPaused: isPaused,
       onPlayPause: onPlayPause,
       onSwitchCamera: onSwitchCamera,
+      isTorchOn: isTorchOn,
+      onToggleTorch: onToggleTorch,
       onShare: onShare,
       onInfo: onInfo,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues

--- a/test/utils/test_helpers.dart
+++ b/test/utils/test_helpers.dart
@@ -430,7 +430,8 @@ class YOLOTestHelpers {
             },
             'setTorchMode': (call) {
               log.add(call);
-              return true;
+              // Echo the requested state, mirroring the native handlers which return the actual resulting state.
+              return (call.arguments as Map)['enabled'] as bool;
             },
             'zoomIn': (call) {
               log.add(call);

--- a/test/yolo_controller_test.dart
+++ b/test/yolo_controller_test.dart
@@ -84,6 +84,17 @@ void main() {
         'setTorchMode',
         arguments: {'enabled': true},
       );
+      expect(controller.isTorchEnabled, isTrue);
+
+      // toggleTorch flips the tracked state and invokes setTorchMode with the negated value.
+      log.clear();
+      await controller.toggleTorch();
+      YOLOTestHelpers.assertMethodCalled(
+        log,
+        'setTorchMode',
+        arguments: {'enabled': false},
+      );
+      expect(controller.isTorchEnabled, isFalse);
 
       await controller.zoomIn();
       YOLOTestHelpers.assertMethodCalled(log, 'zoomIn');


### PR DESCRIPTION
Closes #496.

Torch (flashlight) control already worked end-to-end via `YOLOViewController.setTorchMode(bool)` (added in #435: Dart + Android `enableTorch` + iOS `AVCaptureDevice.torchMode`, all capability-guarded). This PR adds the maintainer-requested `toggleTorch()` convenience and — more importantly — makes the feature **discoverable** by surfacing it in the example UI, which is why the requester didn't realize it existed.

### Changes
- **`YOLOViewController`**: add `toggleTorch()` and an `isTorchEnabled` getter; `setTorchMode` now tracks the torch state so `toggleTorch()` flips it.
- **`CameraToolbar`**: add a torch toggle button (bolt icon) next to the camera-flip control.
- **`YOLOShowcase`**: wire the torch button; reset the torch state when switching the camera input (the new device may not have a torch).
- **`doc/api.md`**: document `toggleTorch()` / `isTorchEnabled`.
- **Tests**: cover `toggleTorch()` + `isTorchEnabled`.

No native changes are required — torch lives entirely in the plugin's camera layer; the shared `UltralyticsYOLO` Swift package is unaffected.

`flutter analyze` clean; 155 tests pass; example app launch smoke test passes on the iOS Simulator.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds camera torch control to the Flutter YOLO app/plugin 🔦, improves torch state tracking across iOS and Android, and updates the showcase UI to place a torch toggle neatly beside the zoom controls.

### 📊 Key Changes
- Added torch support to `YOLOViewController` with:
  - `toggleTorch()`
  - `isTorchEnabled`
  - internal torch state caching 🔁
- Updated native Android and iOS torch handling to return the **actual resulting torch state** instead of just signaling success.
- Improved reliability when a camera has **no flash unit** or torch activation fails, so Flutter stays synced with real hardware behavior ✅
- Added a torch toggle control to `YOLOShowcase`, displayed next to the lens/zoom picker for quicker access 🎛️
- Updated the lens picker layout to support an optional trailing control while keeping zoom options visually centered.
- Reset torch state when switching cameras, preventing the UI from incorrectly showing the torch as still on after a camera change 📷
- Enhanced API docs to describe:
  - `setTorchMode()`
  - new `toggleTorch()`
  - new `isTorchEnabled`
- Changed the showcase’s default model size to **nano** on launch and when switching tasks, matching the native iOS app behavior ⚡
- Bumped package version from `0.5.0` to `0.5.1`
- Added/updated tests to verify torch state behavior and toggling 🧪

### 🎯 Purpose & Impact
- Makes flashlight control easier and more user-friendly during live camera inference 🔦
- Prevents mismatches between the app UI and the device’s real torch state, especially on unsupported cameras or after camera switches.
- Brings Flutter behavior closer to the native iOS experience for both controls and default model selection 📱
- Improves developer ergonomics with a clearer controller API and better-documented torch features.
- Gives end users a smoother showcase experience with faster default startup behavior through the nano model 🚀