### PR TITLE
Stamp the live app version in the showcase bottom-left

### DIFF
--- a/example/lib/presentation/screens/camera_inference_screen.dart
+++ b/example/lib/presentation/screens/camera_inference_screen.dart
@@ -4,17 +4,39 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:ultralytics_yolo/ultralytics_yolo.dart';
 
 /// Real-time YOLO camera inference. Thin shell over [YOLOShowcase] that wires the capture callback to the platform
-/// share sheet via `share_plus`. Kept intentionally bare so the screen reads side-by-side with `yolo-ios-app`'s
-/// `ViewController` — no extra Material chrome on top.
-class CameraInferenceScreen extends StatelessWidget {
+/// share sheet via `share_plus` and stamps the live app version in the bottom-left (matching `yolo-ios-app`). Kept
+/// intentionally bare so the screen reads side-by-side with `yolo-ios-app`'s `ViewController` — no extra Material
+/// chrome on top.
+class CameraInferenceScreen extends StatefulWidget {
   const CameraInferenceScreen({super.key});
 
-  Future<void> _onCapture(BuildContext context, Uint8List bytes) async {
+  @override
+  State<CameraInferenceScreen> createState() => _CameraInferenceScreenState();
+}
+
+class _CameraInferenceScreenState extends State<CameraInferenceScreen> {
+  String? _versionLabel;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    if (!mounted) return;
+    // Match yolo-ios-app's `labelVersion`: "v<version> (<build>)".
+    setState(() => _versionLabel = 'v${info.version} (${info.buildNumber})');
+  }
+
+  Future<void> _onCapture(Uint8List bytes) async {
     // Capture the share-sheet anchor BEFORE any async gap (no BuildContext use after await). iOS 26 gives the activity
     // controller a popoverPresentationController even on iPhone; without a valid source rect the popover anchors at
     // (0,0) and can present/dismiss incorrectly (and it is required on iPad). Use the screen's render box.
@@ -39,7 +61,7 @@ class CameraInferenceScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     // Show all 6 tasks (Detect / Segment / Semantic / Classify / Pose / OBB) to match the iOS app's task control.
     return Scaffold(
-      body: YOLOShowcase(onCapture: (bytes) => _onCapture(context, bytes)),
+      body: YOLOShowcase(versionLabel: _versionLabel, onCapture: _onCapture),
     );
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.4.3+4
+version: 0.5.1+5
 
 environment:
   sdk: ^3.8.1
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   image_picker: ^1.2.1
+  package_info_plus: ^9.0.0
   path_provider: ^2.1.5
   # Pinned to ^12.x: share_plus 13.x ships a Swift Package umbrella that fails framework module verification under
   # Xcode 26.5 ("'Flutter/Flutter.h' file not found", "double-quoted include in framework header"). Revisit once the


### PR DESCRIPTION
Shows the running app version in the bottom-left of `YOLOShowcase` in small font, matching `yolo-ios-app`'s `labelVersion` ("v<version> (<build>)"). The example reads it live via `package_info_plus` and passes it as `YOLOShowcase.versionLabel` (the widget already rendered this slot — it just wasn't wired up).

Also bumps the example app version `0.4.3+4` → `0.5.1+5` so the stamped version matches the current release. Example-only (`publish_to: none`); the plugin version is unchanged — **no pub.dev release**.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds live app version display to the Flutter camera inference demo and updates the example app setup to better match the iOS experience 📱✨

### 📊 Key Changes
- Converted `CameraInferenceScreen` from a `StatelessWidget` to a `StatefulWidget` so it can load and store app version info dynamically.
- Added `package_info_plus` as a dependency to fetch the app version and build number from the device/platform.
- Implemented version loading in `initState()` and formatted it as `v<version> (<build>)` to match the `yolo-ios-app` style.
- Passed the new `versionLabel` into `YOLOShowcase`, which now shows the live app version in the bottom-left corner.
- Kept the existing image capture and share-sheet flow intact, including the iOS-safe popover anchoring behavior.
- Bumped the example app version in `pubspec.yaml` from `0.4.3+4` to `0.5.1+5` 🚀

### 🎯 Purpose & Impact
- Improves consistency between the Flutter example and the iOS app, making cross-platform demos feel more aligned 🔄
- Makes it easier for developers, testers, and users to quickly verify which app build is running 🏷️
- Supports debugging and release validation by showing version details directly in the UI.
- Introduces only a small, low-risk UI/state management change without altering the core YOLO camera inference behavior ✅
- Helps the example app feel more polished and production-like for anyone evaluating or integrating `ultralytics_yolo` 🎉