### PR TITLE
Tuck the showcase version stamp into the bottom-left corner

### DIFF
--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -959,16 +959,22 @@ class _ShowcaseOverlay extends StatelessWidget {
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(_sidePadding, 2, _sidePadding, 2),
-          child: _lensPicker(),
-        ),
-        if (versionLabel != null)
-          Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: _sidePadding,
-              vertical: 4,
-            ),
-            child: Align(alignment: Alignment.centerLeft, child: _version()),
+          child: Stack(
+            alignment: Alignment.center,
+            clipBehavior: Clip.none,
+            children: [
+              _lensPicker(),
+              // Version stamp at the lens-tabs vertical level, tucked into the bottom-left corner (negative left
+              // escapes the row's side padding so it sits closer to the screen edge than the controls).
+              if (versionLabel != null)
+                Positioned(
+                  left: -(_sidePadding - 8),
+                  bottom: 0,
+                  child: _version(),
+                ),
+            ],
           ),
+        ),
         _toolbar(),
       ],
     );
@@ -1184,7 +1190,7 @@ class _ShowcaseOverlay extends StatelessWidget {
       versionLabel!,
       style: TextStyle(
         color: Colors.white.withValues(alpha: 0.7),
-        fontSize: 12,
+        fontSize: 10,
       ),
     );
   }


### PR DESCRIPTION
Refines the `YOLOShowcase` version label: overlay it at the lens-tabs' vertical level (instead of a dedicated full-width row), pinned to the bottom-left corner at a smaller 10pt font — matching `yolo-ios-app`'s `labelVersion` placement. Plugin version unchanged (no pub.dev release).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refines the camera showcase overlay UI in the Flutter app by repositioning the version label and reducing its text size for a cleaner, less distracting layout 📱✨

### 📊 Key Changes
- Moved the version label from its own separate row into the same area as the lens picker using a `Stack`.
- Positioned the version stamp at the bottom-left of the lens control area, slightly closer to the screen edge for a more tucked-away appearance.
- Kept the version label conditional, so it only appears when `versionLabel` is available.
- Reduced the version label font size from `12` to `10` to make it more subtle.

### 🎯 Purpose & Impact
- Improves visual polish by integrating the version label more naturally into the existing camera controls 🎨
- Frees up vertical space in the overlay, helping the interface feel less cluttered and more streamlined.
- Makes the version stamp less prominent, which is helpful for users who care more about the camera controls than build metadata.
- Likely has low functional risk since the change is limited to UI layout and styling, with no core app logic changes ✅