### PR TITLE
Upload explicit Flutter coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          files: coverage/lcov.info
+          disable_search: true
+          plugins: noop
           name: flutter-codecov
           verbose: false
 


### PR DESCRIPTION
## Summary
- point Codecov at Flutter's generated `coverage/lcov.info`
- disable Codecov's broad coverage-file search so CI logs do not report unrelated missing tooling like `xcrun`, `gcov`, or `coverage.py`

## Production CI evidence
- main run `27006005319` passed after #507
- log review showed Codecov found `coverage/lcov.info`, but also emitted unrelated search warnings for tools this Flutter job does not use
- iOS and Android launch coverage remains unchanged; this PR only scopes the coverage upload

## Validation
- `actionlint .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR tightens the CI coverage upload setup by making Codecov use the Flutter-generated coverage report explicitly.

### 📊 Key Changes
- Updated the GitHub Actions CI workflow in `.github/workflows/ci.yml` for the Codecov upload step.
- Added `files: coverage/lcov.info` so Codecov uploads the exact Flutter coverage file.
- Added `disable_search: true` to stop Codecov from scanning the repository for other coverage files.
- Added `plugins: noop` to disable extra plugin behavior during upload.
- Kept the existing upload name as `flutter-codecov` and preserved strict failure behavior with `fail_ci_if_error: true`.

### 🎯 Purpose & Impact
- ✅ Improves reliability of coverage reporting by pointing Codecov to the correct file directly.
- 🚀 Reduces the chance of CI misreporting or missing coverage because of automatic file discovery.
- 🧹 Makes the coverage upload process more predictable and easier to debug.
- 🔒 Helps ensure CI fails when coverage upload has real issues, which supports more trustworthy project health checks for contributors and maintainers.