### PR TITLE
Migrate Android builds to built-in Kotlin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,19 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// Built-in Kotlin migration (https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors):
+// AGP 9+ ships Kotlin support itself; on older AGP (Flutter < 3.44) the plugin still has to apply KGP.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
 
 android {
     namespace = "com.ultralytics.yolo"
@@ -31,10 +43,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin; Kotlin comes from Flutter's
+    // built-in Kotlin support.
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -19,10 +19,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false


### PR DESCRIPTION
## Summary

Flutter 3.41 prints a deprecation advisory on every example Android build: the app and the `ultralytics_yolo` plugin apply the Kotlin Gradle Plugin (KGP), which future Flutter versions will reject in favor of built-in Kotlin. This migrates both, following the official guides ([app](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers), [plugin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors)) and the pattern the Flutter team ships in `flutter/packages` (e.g. `image_picker_android`).

### Changes

- **Example app** (`example/android/app/build.gradle`): drop `id "kotlin-android"` and the `kotlinOptions` block — Flutter's built-in Kotlin support compiles the app's Kotlin. Commit the `android.builtInKotlin`/`android.newDsl` flags to `gradle.properties` that the Flutter migrator was otherwise re-stamping on every build ("Upgrading gradle.properties" in CI logs).
- **Plugin** (`android/build.gradle`): use the plugin-author guide's compatibility path — `kotlin-android` is applied only while AGP < 9 (AGP 9+/Flutter 3.44+ ships Kotlin itself, and Flutter 3.41 does not yet apply Kotlin to plugin projects, so a Kotlin-source plugin still needs KGP there). `android.kotlinOptions` is replaced by the `kotlin { compilerOptions }` DSL. JVM targets stay at 17. The plugin keeps working on current stable and is forward-compatible with AGP 9 with no further change.

### Validation

- `flutter clean && flutter build apk --debug` (example): builds, and the full log contains **zero** "Kotlin Gradle Plugin" advisories (previously two warning blocks: the app project and the plugins list).
- The Flutter migrator no longer modifies `gradle.properties` during builds.
- Plugin Kotlin sources compile through the example build; JVM target unchanged (17).

### Notes

- An unconditional drop of KGP in the plugin would require raising the minimum supported Flutter to 3.44 for all consumers; the conditional path is the guide's documented approach for staying compatible with current stable.
- Third-party plugins (`package_info_plus`, `share_plus`, `wakelock_plus`) still apply KGP internally; with the app itself migrated, Flutter no longer surfaces the advisory for them. Their migrations are upstream work.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the Android/Flutter Gradle setup to support Flutter’s built-in Kotlin migration, improving compatibility with newer Android Gradle Plugin versions while keeping older setups working.

### 📊 Key Changes
- ✅ Made Kotlin plugin application conditional in `android/build.gradle`:
  - Applies `kotlin-android` only when using Android Gradle Plugin versions older than 9.
  - Avoids redundant Kotlin plugin setup on newer Flutter/AGP versions that already include Kotlin support.
- 🆕 Switched Kotlin JVM target configuration to the newer Kotlin DSL:
  - Added `kotlin { compilerOptions { jvmTarget = JVM_17 } }`
  - Removed older `kotlinOptions` blocks.
- 🧹 Cleaned up the example app’s Gradle configuration:
  - Removed explicit `kotlin-android` plugin from `example/android/app/build.gradle`
  - Updated comments to reflect Flutter’s built-in Kotlin support.
- ⚙️ Added Flutter migration flags in `example/android/gradle.properties`:
  - `android.builtInKotlin=false`
  - `android.newDsl=false`

### 🎯 Purpose & Impact
- 🚀 Prepares the Flutter app/plugin for newer Flutter and Android build tooling without breaking older environments.
- 🛠️ Reduces Gradle configuration conflicts by avoiding duplicate Kotlin plugin application.
- 📦 Modernizes the Android build setup with Java 17/Kotlin 17-aligned configuration.
- 👥 Helps developers upgrading Flutter or Android tooling have a smoother migration path with fewer build issues.
- 🔒 Keeps backward compatibility, so users on older Flutter versions should still be able to build successfully.