### PR TITLE
Fix overlay toggling race and expose OBB and frame data for custom overlays (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.6.0
+
+- **Breaking**: Remove the unused `getPlatformVersion` API from the platform interface and method channel — a plugin
+  template leftover with no inference purpose.
+- **Breaking**: Retire YOLO11 from the official auto-download registry; the official set is now the YOLO26 task×size
+  matrix. YOLO11 (and any other) models still load via custom paths or URLs.
+- **Bug Fix**: `YOLOViewController.setShowOverlays` called before the platform view attached was silently dropped;
+  the controller now remembers the requested visibility and applies it on initialization (#506).
+- **Feature**: Streamed OBB detections now always carry top-level `polygon` (pixel) and `polygonNormalized` (0-1)
+  corner points plus `angle` (radians) on both platforms — previously normalized corners required `includeOBB` on
+  Android and iOS live streams carried no parseable polygon at all. `YOLOResult` exposes the normalized corners via
+  the new `obbPointsNormalized` field (#506).
+- **Feature**: Per-frame streaming data now includes `imageWidth`/`imageHeight`, the dimensions of the upright frame
+  that normalized detection coordinates refer to, enabling accurate custom overlay transforms (#506).
+- **Enhancement**: Require UltralyticsYOLO pod `>= 8.9.3`, which adds the matching `YOLOView.showOverlays` toggle
+  upstream.
+- **Enhancement**: Migrate Android builds to Flutter's built-in Kotlin support, readying the plugin for AGP 9.
+- **Enhancement**: Stamp the app version on the example screens, and align GPU fallback wording with whole-model
+  compilation semantics across the docs.
+
 ## 0.5.1
 
 - **Feature**: Expose camera torch control on `YOLOViewController` with `toggleTorch()` and an `isTorchEnabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
   the new `obbPointsNormalized` field (#506).
 - **Feature**: Per-frame streaming data now includes `imageWidth`/`imageHeight`, the dimensions of the upright frame
   that normalized detection coordinates refer to, enabling accurate custom overlay transforms (#506).
-- **Enhancement**: Require UltralyticsYOLO pod `>= 8.9.3`, which adds the matching `YOLOView.showOverlays` toggle
-  upstream.
+- **Enhancement**: Require UltralyticsYOLO pod `>= 8.9.4`, which adds the matching `YOLOView.showOverlays` toggle
+  and a camera torch chip upstream.
 - **Enhancement**: Migrate Android builds to Flutter's built-in Kotlin support, readying the plugin for AGP 9.
 - **Enhancement**: Stamp the app version on the example screens, and align GPU fallback wording with whole-model
   compilation semantics across the docs.

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -1511,6 +1511,9 @@ class YOLOView @JvmOverloads constructor(
                         val enhancedStreamData = HashMap<String, Any>(streamData)
                         enhancedStreamData["timestamp"] = System.currentTimeMillis()
                         enhancedStreamData["frameNumber"] = frameNumberCounter++
+                        // Dimensions of the upright frame that (normalized) detection coordinates refer to (#506)
+                        enhancedStreamData["imageWidth"] = resultWithOriginalImage.origShape.width
+                        enhancedStreamData["imageHeight"] = resultWithOriginalImage.origShape.height
                         
                         callback.invoke(enhancedStreamData)
                     }
@@ -2140,7 +2143,18 @@ class YOLOView @JvmOverloads constructor(
                 
                 // Store polygon points directly for precise OBB cropping
                 detection["polygon"] = polygonPixels
-                
+
+                // Normalized (0-1) corners and rotation angle, always present so custom overlays
+                // can transform OBB detections without enabling includeOBB (#506)
+                val pointsNormalized = polygon.map { point ->
+                    mapOf(
+                        "x" to point.x.toDouble(),
+                        "y" to point.y.toDouble()
+                    )
+                }
+                detection["polygonNormalized"] = pointsNormalized
+                detection["angle"] = obbRes.box.angle.toDouble()
+
                 // Also calculate AABB as fallback for compatibility (but Flutter should use polygon)
                 var minX = Float.MAX_VALUE
                 var maxX = Float.MIN_VALUE  
@@ -2172,13 +2186,6 @@ class YOLOView @JvmOverloads constructor(
                 
                 // Add OBB-specific data
                 if (config.includeOBB) {
-                    val points = polygon.map { point ->
-                        mapOf(
-                            "x" to point.x.toDouble(),
-                            "y" to point.y.toDouble()
-                        )
-                    }
-                    
                     val obbDataMap = mapOf(
                         "centerX" to obbRes.box.cx.toDouble(),
                         "centerY" to obbRes.box.cy.toDouble(),
@@ -2187,7 +2194,7 @@ class YOLOView @JvmOverloads constructor(
                         "angle" to obbRes.box.angle.toDouble(),
                         "angleDegrees" to (obbRes.box.angle * 180.0 / Math.PI),
                         "area" to obbRes.box.area.toDouble(),
-                        "points" to points,
+                        "points" to pointsNormalized,
                         "confidence" to obbRes.confidence.toDouble(),
                         "className" to obbRes.cls,
                         "classIndex" to obbRes.index

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,8 +13,8 @@ PODS:
     - FlutterMacOS
   - ultralytics_yolo (0.6.0):
     - Flutter
-    - UltralyticsYOLO (< 9.0, >= 8.9.3)
-  - UltralyticsYOLO (8.9.3)
+    - UltralyticsYOLO (< 9.0, >= 8.9.4)
+  - UltralyticsYOLO (8.9.4)
   - url_launcher_ios (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
@@ -62,8 +62,8 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  ultralytics_yolo: e4f02daf383b478b55efc5e7e1b64db71d6bcfbf
-  UltralyticsYOLO: 9c8689101352eaf3f0507ed72796a50b801b47c5
+  ultralytics_yolo: b19941dc12a47245d2db81462d4734ac1273e2c8
+  UltralyticsYOLO: 163cd55ce4e0282ebc0d5712dd098d1897d04d7d
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,10 +11,10 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - ultralytics_yolo (0.5.1):
+  - ultralytics_yolo (0.6.0):
     - Flutter
-    - UltralyticsYOLO (< 9.0, >= 8.9.2)
-  - UltralyticsYOLO (8.9.2)
+    - UltralyticsYOLO (< 9.0, >= 8.9.3)
+  - UltralyticsYOLO (8.9.3)
   - url_launcher_ios (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
@@ -62,8 +62,8 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  ultralytics_yolo: 5a0983bdeef69a5c81bd96fa44d2d11c367da7ae
-  UltralyticsYOLO: 7fa3ed5d69c750205a4b2f082ad712795d2ba058
+  ultralytics_yolo: e4f02daf383b478b55efc5e7e1b64db71d6bcfbf
+  UltralyticsYOLO: 9c8689101352eaf3f0507ed72796a50b801b47c5
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.5.1+5
+version: 0.6.0+6
 
 environment:
   sdk: ^3.8.1

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -78,6 +78,9 @@ public class YOLOView: UIView, VideoCaptureDelegate {
         enhancedStreamData["timestamp"] = Int64(Date().timeIntervalSince1970 * 1000)  // milliseconds
         enhancedStreamData["frameNumber"] = frameNumberCounter
         frameNumberCounter += 1
+        // Dimensions of the upright frame that (normalized) detection coordinates refer to (#506)
+        enhancedStreamData["imageWidth"] = Int(result.orig_shape.width)
+        enhancedStreamData["imageHeight"] = Int(result.orig_shape.height)
 
         streamCallback(enhancedStreamData)
       }
@@ -1881,6 +1884,17 @@ extension YOLOView {
             "bottom": Double(maxY),
           ]
 
+          // Pixel + normalized (0-1) corners and rotation angle, always present so custom overlays
+          // can transform OBB detections without enabling includeOBB (#506)
+          detection["polygon"] = polygon.map { point in
+            [
+              "x": Double(point.x * imgWidth),
+              "y": Double(point.y * imgHeight),
+            ]
+          }
+          detection["polygonNormalized"] = points
+          detection["angle"] = Double(obbResult.box.angle)
+
           if config.includeOBB {
             detection["obb"] = [
               "centerX": Double(obbResult.box.cx),
@@ -1970,6 +1984,16 @@ extension YOLOView {
               "y": Double(point.y),
             ]
           }
+
+          // Top-level pixel/normalized corners and angle, matching the OBB-only path (#506)
+          detection["polygon"] = polygon.map { point in
+            [
+              "x": Double(point.x * result.orig_shape.width),
+              "y": Double(point.y * result.orig_shape.height),
+            ]
+          }
+          detection["polygonNormalized"] = points
+          detection["angle"] = Double(obbBox.angle)
 
           // Create comprehensive OBB data map
           let obbDataMap: [String: Any] = [

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ultralytics_yolo'
-  s.version          = '0.5.1'
+  s.version          = '0.6.0'
   s.summary          = 'Flutter plugin for YOLO (You Only Look Once) models'
   s.description      = <<-DESC
 Flutter plugin for YOLO (You Only Look Once) models, supporting object detection, segmentation, classification, pose estimation and oriented bounding boxes (OBB) on both Android and iOS.
@@ -17,7 +17,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # `no rule to process file ... net.daringfireball.markdown` warning on every Xcode build.
   s.source_files = 'Classes/**/*.{swift,h,m}'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.2', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.3', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -17,7 +17,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # `no rule to process file ... net.daringfireball.markdown` warning on every Xcode build.
   s.source_files = 'Classes/**/*.{swift,h,m}'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.3', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.4', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/models/yolo_result.dart
+++ b/lib/models/yolo_result.dart
@@ -80,8 +80,14 @@ class YOLOResult {
   /// Only available when using OBB models (YOLOTask.obb).
   final double? angle;
 
-  /// Polygon points for oriented bounding boxes.
+  /// Polygon corner points for oriented bounding boxes, in pixel coordinates of the camera frame.
   final List<Map<String, num>>? obbPoints;
+
+  /// Polygon corner points for oriented bounding boxes, normalized to 0.0-1.0.
+  ///
+  /// Multiply by the frame dimensions (`imageWidth`/`imageHeight` in streaming data) or your own
+  /// render size to draw custom OBB overlays.
+  final List<Map<String, num>>? obbPointsNormalized;
 
   YOLOResult({
     required this.classIndex,
@@ -94,6 +100,7 @@ class YOLOResult {
     this.keypointConfidences,
     this.angle,
     this.obbPoints,
+    this.obbPointsNormalized,
   });
 
   /// Creates a [YOLOResult] from a map representation.
@@ -142,18 +149,8 @@ class YOLOResult {
     }
 
     final angle = map['angle'] is num ? (map['angle'] as num).toDouble() : null;
-    final polygonRaw = map['polygon'] ?? map['obbPoints'];
-    List<Map<String, num>>? obbPoints;
-    if (polygonRaw is List) {
-      obbPoints = <Map<String, num>>[];
-      for (final point in polygonRaw) {
-        if (point is! Map) continue;
-        final x = point['x'];
-        final y = point['y'];
-        if (x is! num || y is! num) continue;
-        obbPoints.add({'x': x.toDouble(), 'y': y.toDouble()});
-      }
-    }
+    final obbPoints = _parsePolygonPoints(map['polygon'] ?? map['obbPoints']);
+    final obbPointsNormalized = _parsePolygonPoints(map['polygonNormalized']);
 
     return YOLOResult(
       classIndex: classIndex,
@@ -166,7 +163,22 @@ class YOLOResult {
       keypointConfidences: keypointConfidences,
       angle: angle,
       obbPoints: obbPoints,
+      obbPointsNormalized: obbPointsNormalized,
     );
+  }
+
+  /// Parses a list of `{x, y}` maps, keeping only valid numeric points.
+  static List<Map<String, num>>? _parsePolygonPoints(dynamic raw) {
+    if (raw is! List) return null;
+    final points = <Map<String, num>>[];
+    for (final point in raw) {
+      if (point is! Map) continue;
+      final x = point['x'];
+      final y = point['y'];
+      if (x is! num || y is! num) continue;
+      points.add({'x': x.toDouble(), 'y': y.toDouble()});
+    }
+    return points;
   }
 
   Map<String, dynamic> toMap() {
@@ -208,6 +220,10 @@ class YOLOResult {
 
     if (obbPoints != null) {
       map['polygon'] = obbPoints;
+    }
+
+    if (obbPointsNormalized != null) {
+      map['polygonNormalized'] = obbPointsNormalized;
     }
 
     return map;

--- a/lib/widgets/yolo_controller.dart
+++ b/lib/widgets/yolo_controller.dart
@@ -37,6 +37,7 @@ class YOLOViewController {
   double _iouThreshold = 0.7;
   int _numItemsThreshold = 30;
   bool _torchEnabled = false;
+  bool _showOverlays = true;
 
   final StreamController<double> _zoomController =
       StreamController<double>.broadcast();
@@ -52,6 +53,9 @@ class YOLOViewController {
 
   /// Whether the torch (flashlight) is currently enabled, per the last [setTorchMode]/[toggleTorch] call.
   bool get isTorchEnabled => _torchEnabled;
+
+  /// Whether native prediction overlays are shown, per the last [setShowOverlays] call.
+  bool get showOverlays => _showOverlays;
 
   /// Emits the native zoom factor whenever it changes (e.g. via pinch).
   Stream<double> get zoomEvents => _zoomController.stream;
@@ -72,6 +76,10 @@ class YOLOViewController {
       'iouThreshold': _iouThreshold,
       'numItemsThreshold': _numItemsThreshold,
     });
+    // Re-apply state set before the platform view attached, which would otherwise be silently dropped.
+    if (!_showOverlays) {
+      _invoke('setShowOverlays', {'visible': false});
+    }
   }
 
   Future<T?> _invoke<T>(String method, [Map<String, dynamic>? args]) async {
@@ -166,8 +174,12 @@ class YOLOViewController {
       _invoke('tapToFocus', {'x': x, 'y': y});
 
   /// Shows or hides native prediction overlays without changing inference callbacks.
-  Future<void> setShowOverlays(bool visible) =>
-      _invoke('setShowOverlays', {'visible': visible});
+  ///
+  /// Safe to call before the view attaches: the value is remembered and applied on initialization.
+  Future<void> setShowOverlays(bool visible) {
+    _showOverlays = visible;
+    return _invoke('setShowOverlays', {'visible': visible});
+  }
 
   /// Captures a still photo from the live preview.
   ///

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -31,6 +31,10 @@ class YOLOView extends StatefulWidget {
   final String cameraResolution;
   final Function(List<YOLOResult>)? onResult;
   final Function(YOLOPerformanceMetrics)? onPerformanceMetrics;
+
+  /// Raw per-frame streaming data. Top-level keys include `detections`, `fps`, `processingTimeMs`,
+  /// `timestamp`, `frameNumber`, and `imageWidth`/`imageHeight` — the dimensions of the upright frame
+  /// that normalized detection coordinates refer to, for custom overlay transforms.
   final Function(Map<String, dynamic>)? onStreamingData;
   final Function(double zoomLevel)? onZoomChanged;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.5.1
+version: 0.6.0
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues

--- a/test/yolo_controller_test.dart
+++ b/test/yolo_controller_test.dart
@@ -123,20 +123,23 @@ void main() {
       YOLOTestHelpers.assertMethodCalled(log, 'captureFrame');
     });
 
-    test('setShowOverlays before init is remembered and applied on init', () async {
-      // Called before the platform view attaches: no channel yet, so the call is only recorded locally.
-      await controller.setShowOverlays(false);
-      expect(controller.showOverlays, isFalse);
-      expect(log, isEmpty);
+    test(
+      'setShowOverlays before init is remembered and applied on init',
+      () async {
+        // Called before the platform view attaches: no channel yet, so the call is only recorded locally.
+        await controller.setShowOverlays(false);
+        expect(controller.showOverlays, isFalse);
+        expect(log, isEmpty);
 
-      controller.init(mockChannel, 1);
+        controller.init(mockChannel, 1);
 
-      YOLOTestHelpers.assertMethodCalled(
-        log,
-        'setShowOverlays',
-        arguments: {'visible': false},
-      );
-    });
+        YOLOTestHelpers.assertMethodCalled(
+          log,
+          'setShowOverlays',
+          arguments: {'visible': false},
+        );
+      },
+    );
 
     test('lens, focus, and photo methods invoke platform channel', () async {
       final calls = <MethodCall>[];

--- a/test/yolo_controller_test.dart
+++ b/test/yolo_controller_test.dart
@@ -115,11 +115,27 @@ void main() {
         'setShowOverlays',
         arguments: {'visible': false},
       );
+      expect(controller.showOverlays, isFalse);
 
       // Test capture frame
       final result = await controller.captureFrame();
       expect(result, isA<Uint8List>());
       YOLOTestHelpers.assertMethodCalled(log, 'captureFrame');
+    });
+
+    test('setShowOverlays before init is remembered and applied on init', () async {
+      // Called before the platform view attaches: no channel yet, so the call is only recorded locally.
+      await controller.setShowOverlays(false);
+      expect(controller.showOverlays, isFalse);
+      expect(log, isEmpty);
+
+      controller.init(mockChannel, 1);
+
+      YOLOTestHelpers.assertMethodCalled(
+        log,
+        'setShowOverlays',
+        arguments: {'visible': false},
+      );
     });
 
     test('lens, focus, and photo methods invoke platform channel', () async {

--- a/test/yolo_result_test.dart
+++ b/test/yolo_result_test.dart
@@ -184,6 +184,47 @@ void main() {
       ]);
     });
 
+    test('fromMap parses normalized polygon points and round-trips them', () {
+      final map = {
+        'classIndex': 1,
+        'className': 'airplane',
+        'confidence': 0.92,
+        'boundingBox': {
+          'left': 100.0,
+          'top': 150.0,
+          'right': 300.0,
+          'bottom': 250.0,
+        },
+        'normalizedBox': {
+          'left': 0.1,
+          'top': 0.15,
+          'right': 0.3,
+          'bottom': 0.25,
+        },
+        'polygon': [
+          {'x': 100.0, 'y': 150.0},
+          {'x': 300.0, 'y': 250.0},
+        ],
+        'polygonNormalized': [
+          {'x': 0.1, 'y': 0.15},
+          {'x': 0.3, 'y': 0.25},
+        ],
+        'angle': 0.25,
+      };
+
+      final result = YOLOResult.fromMap(map);
+
+      expect(result.obbPointsNormalized, [
+        {'x': 0.1, 'y': 0.15},
+        {'x': 0.3, 'y': 0.25},
+      ]);
+
+      final roundTrip = YOLOResult.fromMap(result.toMap());
+      expect(roundTrip.obbPoints, result.obbPoints);
+      expect(roundTrip.obbPointsNormalized, result.obbPointsNormalized);
+      expect(roundTrip.angle, result.angle);
+    });
+
     test('constructor creates instance with all parameters', () {
       final keypoints = [Keypoint(0.5, 0.3), Keypoint(0.6, 0.4)];
       final keypointConfidences = [0.8, 0.9];


### PR DESCRIPTION
## Summary

Fixes the three problems reported in #506.

### `setShowOverlays` dropped before the view attaches (Bug)

`YOLOViewController` methods silently no-op until the platform view binds the method channel, so `setShowOverlays(false)` called early (the natural place — right after building the view) never reached the native side and overlays stayed visible. The controller now remembers the requested visibility and `init` re-applies it on attach, the same pattern already used for thresholds. New `showOverlays` getter mirrors `isTorchEnabled`.

### Normalized OBB corners unavailable (Feature)

- Streamed OBB detections now always carry top-level `polygon` (pixel), `polygonNormalized` (0–1), and `angle` (radians) on **both** platforms. Previously: Android sent only the pixel `polygon` top-level (normalized corners were nested under `obb` and gated on `includeOBB`), and iOS live streams nested everything under `obb` — so Dart's `obbPoints`/`angle` parsed as `null` on iOS streams entirely.
- `YOLOResult` gains `obbPointsNormalized`, parsed from `polygonNormalized` and round-tripped in `toMap`; `obbPoints` is now documented as pixel-space.

### Camera frame dimensions for custom overlays (Feature)

Per-frame streaming data now includes top-level `imageWidth`/`imageHeight` — the dimensions of the frame that normalized detection coordinates refer to. Both platforms deliver coordinates in an already-upright frame (Android rotates during inference, iOS pre-rotates capture buffers), so no rotation compensation is needed for overlay transforms: scale normalized coordinates by your render size (aspect-fit/fill against `imageWidth × imageHeight`) and draw.

### Versioning

`0.6.0` — minor bump because main already carries two unreleased breaking changes from #514 (removed `getPlatformVersion`, YOLO11 retired from official auto-download), now called out in the CHANGELOG alongside this PR's changes. The iOS pod dependency moves to `UltralyticsYOLO >= 8.9.4`, which adds the matching native `YOLOView.showOverlays` toggle (ultralytics/yolo-ios-app#267) and camera torch chip (ultralytics/yolo-ios-app#268) upstream.

## Validation

- `flutter analyze` — clean
- `flutter test` — full suite passing, including new tests for pre-attach `setShowOverlays` replay and `polygonNormalized` parse/round-trip
- `dart pub publish --dry-run` — passes

Fixes #506 (the overlay-visibility report itself did not reproduce in v0.5.1 sources — the renderer honors the flag on both platforms; the early-call race above is the likely cause and is now fixed).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR releases `0.6.0` for the Flutter YOLO plugin, improving OBB streaming data, fixing overlay visibility behavior, updating iOS dependencies, and removing outdated APIs/model defaults.

### 📊 Key Changes
- 🧭 **Improved OBB output on Android and iOS**
  - Streamed detections now always include:
    - `polygon` in pixel coordinates
    - `polygonNormalized` in normalized coordinates
    - `angle` at the top level
  - `YOLOResult` adds a new `obbPointsNormalized` field to expose normalized OBB corner points.
- 📐 **Added frame dimensions to streaming data**
  - Per-frame callbacks now include `imageWidth` and `imageHeight`, making it easier to correctly draw custom overlays.
- 🐞 **Fixed `setShowOverlays()` timing issue**
  - If overlay visibility is set before the platform view is fully attached, the controller now remembers that state and applies it once initialized.
- 💥 **Breaking cleanup changes**
  - Removed the unused `getPlatformVersion` API from the platform interface/method channel.
  - Removed YOLO11 from the official auto-download registry; the default official registry now focuses on the YOLO26 task-by-size lineup.
- 🔧 **Dependency and platform updates**
  - iOS now requires `UltralyticsYOLO >= 8.9.4`, enabling matching overlay toggle support and upstream camera UI improvements.
  - Android build setup was modernized to use Flutter’s built-in Kotlin support, helping prepare for newer Android tooling.
- 🏷️ **Version bump and test updates**
  - Plugin and example app versions were updated to `0.6.0`.
  - Tests were added/updated to cover overlay state persistence and normalized polygon parsing.

### 🎯 Purpose & Impact
- 🎨 **Better custom overlays**
  - Developers can now reliably render oriented bounding boxes using consistent polygon data and frame dimensions on both platforms.
- 🔄 **More consistent cross-platform behavior**
  - Android and iOS now expose OBB streaming data in a more unified way, reducing platform-specific handling.
- ✅ **More reliable UI control**
  - Overlay visibility settings now work as expected even if called early during widget setup.
- 🧹 **Cleaner API surface**
  - Removing unused legacy APIs reduces confusion and maintenance overhead.
- 📦 **Shift toward YOLO26 defaults**
  - The plugin now aligns official auto-download behavior with the current recommended Ultralytics model family, while still allowing custom model paths and URLs.
- 🛠️ **Better future compatibility**
  - Updated dependencies and Android build changes help keep the plugin ready for newer iOS and Android toolchains.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `example/ios/Podfile.lock`
</details>
