### PR TITLE
Validate bundled model archives before install in fetch_bundled_models.sh

### DIFF
--- a/scripts/fetch_bundled_models.sh
+++ b/scripts/fetch_bundled_models.sh
@@ -82,11 +82,15 @@ fetch() {
   rm -f "$tmp"
   echo "fetch_bundled_models: downloading $name"
   if curl -fL --retry 3 --retry-delay 2 --connect-timeout 15 -o "$tmp" "$BASE/$name"; then
-    if [ -s "$tmp" ]; then
-      mv -f "$tmp" "$out"
-    else
+    if [ ! -s "$tmp" ]; then
       echo "fetch_bundled_models: WARNING $name downloaded 0 bytes; will fall back to runtime download" >&2
       rm -f "$tmp"
+    elif [[ "$name" == *.zip ]] && ! unzip -tqq "$tmp" > /dev/null 2>&1; then
+      # A truncated or error-page response can still be a non-empty 200; never bundle a corrupt archive.
+      echo "fetch_bundled_models: WARNING $name archive is corrupt or truncated; will fall back to runtime download" >&2
+      rm -f "$tmp"
+    else
+      mv -f "$tmp" "$out"
     fi
   else
     echo "fetch_bundled_models: WARNING failed to download $name; will fall back to runtime download" >&2


### PR DESCRIPTION
## Summary

Companion to ultralytics/yolo-ios-app#270. CI in the iOS repo hit a truncated model download where the server returned a non-empty 200 body that wasn't a valid zip — `curl` reported success and the failure only surfaced later at extraction.

`fetch_bundled_models.sh` already has `curl -fL --retry 3`, an atomic temp file, and a non-empty check, but a truncated-yet-non-empty 200 response would still get installed as a corrupt `.mlpackage.zip` in the app bundle, where it would fail extraction at runtime instead of falling back to the network download.

## Changes

- Validate `.zip` downloads with `unzip -t` before moving them into `example/assets/models/`; reject corrupt/truncated archives with a warning so the app falls back to its runtime download (which already validates transfers).
- Keeps the script's best-effort contract: always exits 0, bundling remains an optimization, never a hard build dependency.

## Testing

- Stubbed `curl` to write a non-zip body with exit 0 and ran `FORCE_BUNDLED_MODELS=1 scripts/fetch_bundled_models.sh ios`: all six archives rejected with clear warnings, nothing installed, script exits 0.
- Confirmed real release `.mlpackage.zip` archives pass the `unzip -t` check.
- `shellcheck` clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛡️ This PR makes bundled model downloads safer by rejecting empty or corrupted `.zip` files during fetch, helping the app avoid shipping broken model assets.

### 📊 Key Changes
- Added a stricter validation step in `scripts/fetch_bundled_models.sh` for downloaded bundled models.
- Kept the existing check for **empty downloads** and slightly simplified its logic.
- Added a new check for `.zip` files using `unzip -tqq` to verify the archive is valid before bundling it.
- If a downloaded archive is corrupt or truncated, the script now:
  - logs a warning
  - deletes the bad temporary file
  - falls back to **runtime download** instead of packaging a broken file
- Included a helpful comment noting that some failed downloads may still return a non-empty file, such as an error page or partial archive.

### 🎯 Purpose & Impact
- ✅ Prevents corrupted model archives from being bundled into the Flutter app.
- 🚫 Reduces the risk of app failures caused by invalid prepackaged model files.
- 🔄 Preserves reliability by falling back to runtime download when bundled assets are unusable.
- 🧩 Improves build robustness, especially in cases of flaky network responses or incomplete downloads.
- 👥 Benefits both developers and end users by making model delivery more dependable with minimal behavior changes.