### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dart pub publish --dry-run
 
       - name: Upload Coverage Reports to CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `codecov/codecov-action@v7` instead of `@v6` for uploading coverage reports.

### 📊 Key Changes
- Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml`
  - from `codecov/codecov-action@v6`
  - to `codecov/codecov-action@v7`
- No application code or Flutter app functionality was changed 📱
- The update only affects the CI pipeline’s coverage report upload step 🛠️

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping dependencies up to date ✅
- Helps ensure continued compatibility with the latest Codecov GitHub Action releases 🔒
- Reduces the risk of issues caused by using an older CI integration version ⚡
- Has no direct impact on end users of the app, but supports a healthier and more reliable development workflow 🚀