### PR TITLE
Fix AGP 9 Kotlin compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+- **Bug Fix**: Fix Android builds on AGP 9 by letting built-in Kotlin inherit the Java 17 target from
+  `compileOptions` and registering Kotlin sources through the Kotlin source set (#520).
+
 ## 0.6.0
 
 - **Breaking**: Remove the unused `getPlatformVersion` API from the platform interface and method channel — a plugin

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,13 +26,14 @@ apply plugin: "com.android.library"
 // Built-in Kotlin migration (https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors):
 // AGP 9+ ships Kotlin support itself; on older AGP (Flutter < 3.44) the plugin still has to apply KGP.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinEnabled = !"false".equalsIgnoreCase(providers.gradleProperty("android.builtInKotlin").orNull)
+if (agpMajor < 9 || !builtInKotlinEnabled) {
     apply plugin: "kotlin-android"
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 
@@ -46,8 +47,8 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += "src/main/kotlin"
-        test.java.srcDirs += "src/test/kotlin"
+        main.kotlin.srcDirs += "src/main/kotlin"
+        test.kotlin.srcDirs += "src/test/kotlin"
     }
 
     // NDK version: Use project property if set by host app, otherwise use a compatible default

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.0+6
+version: 0.6.1+7
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary
- apply the Kotlin Gradle plugin when AGP built-in Kotlin is unavailable or explicitly disabled
- register Android Kotlin sources through the Kotlin source set
- bump the package and example to 0.6.1

Closes #520

## Validation
- flutter analyze
- flutter test
- flutter build apk --debug (from example/)
- dart pub publish --dry-run
- temporary AGP 9.1.0 / Gradle 9.3.1 configuration check with android.builtInKotlin=false reproduced the previous kotlin() failure before the patch and passed after the patch

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR releases `ultralytics_yolo` 0.6.1 and fixes Android build compatibility issues with AGP 9 and built-in Kotlin support.

### 📊 Key Changes
- Updated the plugin version from `0.6.0` to `0.6.1`, and the example app to `0.6.1+7` 📦
- Fixed Android builds for projects using **Android Gradle Plugin 9** by adjusting how Kotlin is configured 🛠️
- Added logic to only apply the `kotlin-android` plugin when needed:
  - for AGP versions below 9
  - or when built-in Kotlin is explicitly disabled
- Moved Kotlin compiler configuration so it only runs when the external Kotlin plugin is applied ✅
- Changed Android source set registration from Java source dirs to proper Kotlin source dirs:
  - `main.kotlin.srcDirs += "src/main/kotlin"`
  - `test.kotlin.srcDirs += "src/test/kotlin"` 📁
- Documented the fix in the changelog as an Android/AGP 9 bug fix 📝

### 🎯 Purpose & Impact
- Ensures the Flutter plugin builds correctly in newer Android environments that use **AGP 9’s built-in Kotlin support** 🚀
- Prevents build failures caused by conflicting or unnecessary Kotlin plugin setup on modern Android toolchains
- Improves compatibility across both older and newer Flutter/Android setups, making the plugin more reliable for a wider range of users 🔄
- Reduces friction for developers integrating Ultralytics YOLO into Flutter apps, especially when upgrading Android build tools 🙌
- This is a maintenance and compatibility release, so users should expect smoother Android builds rather than new app-facing features 🎯