### PR TITLE
Fix Codecov OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
   checks: write
   pull-requests: write
 
@@ -49,7 +50,7 @@ jobs:
       - name: Upload Coverage Reports to CodeCov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: true
           files: coverage/lcov.info
           disable_search: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml)
 [![.github/workflows/ci.yml](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ultralytics/yolo-flutter-app/graph/badge.svg?token=8lpScd9O2a)](https://app.codecov.io/gh/ultralytics/yolo-flutter-app)
+[![codecov](https://codecov.io/github/ultralytics/yolo-flutter-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-flutter-app)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml)
 [![.github/workflows/ci.yml](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ultralytics/yolo-flutter-app/graph/badge.svg?token=8lpScd9O2a)](https://app.codecov.io/gh/ultralytics/yolo-flutter-app)
+[![codecov](https://codecov.io/github/ultralytics/yolo-flutter-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-flutter-app)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- switch the Codecov upload to GitHub OIDC auth and fail loudly
- remove tokenized Codecov README badge URLs

## Validation
- ruby YAML parse for .github/workflows/*.yml
- actionlint .github/workflows/ci.yml
- git diff --check

Note: full actionlint still reports existing shellcheck SC2086 warnings in .github/workflows/tag.yml, which is outside this PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates CI coverage uploads to use GitHub OIDC authentication instead of a stored Codecov token, while also refreshing README coverage badges.

### 📊 Key Changes
- 🔑 Added `id-token: write` permission to the GitHub Actions CI workflow.
- ☁️ Switched the Codecov upload step from using `secrets.CODECOV_TOKEN` to `use_oidc: true`.
- ✅ Kept existing coverage upload checks in place, including failing CI if the upload errors.
- 🏷️ Updated the Codecov badge URLs in both `README.md` and `README.zh-CN.md` to the newer branch-specific Codecov format.

### 🎯 Purpose & Impact
- 🛡️ Improves security by removing reliance on a long-lived secret token for Codecov uploads.
- ⚙️ Simplifies CI maintenance, since there is one less repository secret to manage.
- 📈 Makes coverage reporting more robust and aligned with modern GitHub Actions authentication practices.
- 🌍 Keeps both English and Chinese READMEs consistent, with updated badges that should better reflect coverage status on the main branch.
- 👩‍💻 For most users, this has no app-level feature impact, but it helps maintainers run a cleaner, safer, and easier-to-manage development workflow.