### PR TITLE
Tighten Codecov OIDC permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
   checks: write
   pull-requests: write
 
@@ -24,6 +23,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- move Codecov OIDC permission from workflow-wide permissions to the tests job that uploads coverage
- keep existing top-level contents/checks/pull-requests permissions for the rest of CI

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'\n- actionlint .github/workflows/ci.yml\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR tightens GitHub Actions security by limiting `id-token` permission to only the CI test job that actually needs it.

### 📊 Key Changes
- Removed `id-token: write` from the workflow’s global `permissions` block.
- Added a job-specific `permissions` block under the `tests` job.
- Kept other permissions like `contents`, `checks`, and `pull-requests` available where needed for CI reporting and PR feedback.
- No app code or Flutter functionality was changed—this update only affects the GitHub CI workflow. 🛠️

### 🎯 Purpose & Impact
- Improves security by following the principle of least privilege 🔒
- Reduces unnecessary token access across the entire workflow, lowering risk if other jobs are added later.
- Makes CI permissions more explicit and easier to maintain ✅
- Has no user-facing impact on the app itself, but helps keep the repository’s automation safer and cleaner for contributors 🚀