### PR TITLE
Add pre/inference/post timing breakdown and backend benchmarks

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
@@ -102,7 +102,9 @@ class Classifier(
             ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues, INPUT_MEAN, INPUT_STD)
         }
 
+        val preEnd = System.nanoTime()
         val scores = rtModel.run(floatInput)[0] // flat FloatArray(numClass)
+        val inferEnd = System.nanoTime()
         val indexedScores = scores.mapIndexed { index, score -> index to score }
         val sorted = indexedScores.sortedByDescending { it.second }
 
@@ -128,12 +130,15 @@ class Classifier(
             top5Indices = top5Indices
         )
 
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
         return YOLOResult(
             origShape = Size(origWidth, origHeight),
             probs = probs,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
@@ -86,7 +86,9 @@ class ObbDetector(
         ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
 
         // Reshape the flat output into rawOutput[0][outChannels][outAnchors].
+        val preEnd = System.nanoTime()
         val flat = rtModel.run(floatInput)[0]
+        val inferEnd = System.nanoTime()
         var idx = 0
         for (c in 0 until outChannels) {
             val row = rawOutput[0][c]
@@ -115,13 +117,16 @@ class ObbDetector(
             drawOBBsOnBitmap(bitmap, limitedDetections, origWidth, origHeight)
         }
 
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
         return YOLOResult(
             origShape = Size(origWidth, origHeight),
             obb = limitedDetections,
             annotatedImage = annotatedImage,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
@@ -111,7 +111,9 @@ class ObjectDetector(
         )
 
         // ======== Inference ============
+        val preEnd = System.nanoTime()
         val outputs = rtModel.run(floatInput)
+        val inferEnd = System.nanoTime()
 
         // Reshape the flat [out1*out2] output back into rawOutput[0][out1][out2] for the existing postprocess.
         val flat = outputs[0]
@@ -160,13 +162,16 @@ class ObjectDetector(
             }
         }
 
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
 
         return YOLOResult(
             origShape = com.ultralytics.yolo.Size(origWidth, origHeight),
             boxes = boxes,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -108,7 +108,9 @@ class PoseEstimator(
         ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
 
         // Reshape the flat output into outputArray[0] for the existing pose postprocess.
+        val preEnd = System.nanoTime()
         val flat = rtModel.run(floatInput)[0]
+        val inferEnd = System.nanoTime()
         val rows = outputArray[0]
         var idx = 0
         for (r in rows.indices) {
@@ -132,7 +134,7 @@ class PoseEstimator(
         val boxes = limitedDetections.map { it.box }
         val keypointsList = limitedDetections.map { it.keypoints }
 
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
         // Pack into YOLOResult and return
         return YOLOResult(
             origShape = com.ultralytics.yolo.Size(origWidth, origHeight),
@@ -140,6 +142,9 @@ class PoseEstimator(
             keypointsList = keypointsList,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
@@ -113,10 +113,14 @@ abstract class BasePredictor : Predictor {
 
     protected data class FrameTiming(
         val speedMs: Double,
-        val fps: Double
+        val fps: Double,
+        val preMs: Double,
+        val inferenceMs: Double,
+        val postMs: Double,
     )
 
-    protected fun finishTiming(): FrameTiming {
+    /** Finalize per-frame timing. [preEnd] and [inferEnd] are nanoTime stamps after preprocessing and inference. */
+    protected fun finishTiming(preEnd: Long, inferEnd: Long): FrameTiming {
         val now = System.nanoTime()
         val dtMs = (now - t0) / 1_000_000.0
         t2 = 0.05 * dtMs + 0.95 * t2
@@ -124,7 +128,10 @@ abstract class BasePredictor : Predictor {
         t3 = now
         return FrameTiming(
             speedMs = dtMs,
-            fps = if (t4 > 0.0) 1.0 / t4 else 0.0
+            fps = if (t4 > 0.0) 1.0 / t4 else 0.0,
+            preMs = (preEnd - t0) / 1_000_000.0,
+            inferenceMs = (inferEnd - preEnd) / 1_000_000.0,
+            postMs = (now - inferEnd) / 1_000_000.0,
         )
     }
 

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -106,20 +106,25 @@ class Segmenter(
 
         numClasses = out0NumFeatures - boxFeatureLength - maskConfidenceLength
 
+        val preEnd = System.nanoTime()
         val outs = try {
             rtModel.run(floatInput)
         } catch (e: Exception) {
             Log.e("Segmenter", "Inference error: ${e.message}")
-            val timing = finishTiming()
+            val timing = finishTiming(preEnd, System.nanoTime())
             return YOLOResult(
                 origShape = com.ultralytics.yolo.Size(origWidth, origHeight),
                 boxes = emptyList(),
                 speed = timing.speedMs,
                 fps = timing.fps,
+                preMs = timing.preMs,
+                inferenceMs = timing.inferenceMs,
+                postMs = timing.postMs,
                 names = labels
             )
         }
 
+        val inferEnd = System.nanoTime()
         // Index the flat run() outputs directly — no per-frame reshape into jagged nested arrays.
         val detFlat = outs[detOutIndex]
         val maskFlat = outs[maskOutIndex]
@@ -154,13 +159,16 @@ class Segmenter(
             returnIndividualMasks = includeRawMaskData
         )
         val masks = Masks(probMasks ?: emptyList(), combinedMask)
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
         return YOLOResult(
             origShape = com.ultralytics.yolo.Size(origWidth, origHeight),
             boxes = boxes,
             masks = masks,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
@@ -66,10 +66,12 @@ class SemanticSegmenter(
         ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
 
         // Keep the model output flat; postProcessSemantic indexes it directly (no per-frame reshape copy).
+        val preEnd = System.nanoTime()
         flatOutput = rtModel.run(floatInput)[0]
+        val inferEnd = System.nanoTime()
         val semanticMask = postProcessSemantic(origWidth, origHeight)
         val annotatedImage = drawSemanticOverlay(bitmap, semanticMask)
-        val timing = finishTiming()
+        val timing = finishTiming(preEnd, inferEnd)
         return YOLOResult(
             origShape = Size(origWidth, origHeight),
             boxes = emptyList(),
@@ -77,6 +79,9 @@ class SemanticSegmenter(
             annotatedImage = annotatedImage,
             speed = timing.speedMs,
             fps = timing.fps,
+            preMs = timing.preMs,
+            inferenceMs = timing.inferenceMs,
+            postMs = timing.postMs,
             names = labels
         )
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
@@ -375,8 +375,11 @@ class YOLOPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCallHandler
               if (annotated !== bitmap) annotated.recycle()
             }
   
-            // Include inference speed
+            // Include timing: total speed plus the pre/inference/post breakdown
             response["speed"] = yoloResult.speed
+            response["preMs"] = yoloResult.preMs
+            response["inferenceMs"] = yoloResult.inferenceMs
+            response["postMs"] = yoloResult.postMs
   
             result.success(response)
           } finally {

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOResult.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOResult.kt
@@ -17,6 +17,9 @@ data class YOLOResult(
     val annotatedImage: Bitmap? = null,
     val speed: Double,
     val fps: Double? = null,
+    val preMs: Double = 0.0,
+    val inferenceMs: Double = 0.0,
+    val postMs: Double = 0.0,
     val originalImage: Bitmap? = null,
     val names: List<String>
 )

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -2272,6 +2272,9 @@ class YOLOView @JvmOverloads constructor(
         if (config.includeProcessingTimeMs) {
             val processingTimeMs = result.speed.toDouble()
             map["processingTimeMs"] = processingTimeMs
+            map["preMs"] = result.preMs
+            map["inferenceMs"] = result.inferenceMs
+            map["postMs"] = result.postMs
         }
         
         if (config.includeFps) {

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -54,8 +54,11 @@ with the preprocess / inference / postprocess split beneath it.
   the same release via the ONNX Runtime QNN Execution Provider.
 - <sup>1</sup> Semantic QNN currently returns full float logits (~20M values at 1024px) that are argmax-decoded on the
   CPU, while the TFLite graph emits a compact class map — embedding the argmax in the export is a tracked follow-up.
-- Numbers vary with device generation and thermal state; treat them as relative guidance and benchmark your exact
-  models on your target hardware.
+- **These are single-image burst latencies**, not sustained camera frame times: one photo through `predict()` on a
+  thermally rested device. Real-time camera operation runs higher — full-sensor frames are letterboxed to the model
+  input every frame and the silicon thermally settles under load (on an iPhone 17 Pro, YOLO26n detect measures
+  ~3.8 ms burst but ~16 ms/frame sustained in the live camera). Watch the in-app pre/inference/post HUD line for
+  your device's steady-state numbers, and benchmark your exact models on your target hardware.
 
 ## 🎚️ Tune Thresholds
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -32,28 +32,29 @@ Use a simple rule:
 
 ## 📊 Measured Backend Performance
 
-End-to-end `predict()` times for the official YOLO26n models, measured on a Snapdragon 8 Elite Gen 5 phone
-(Xiaomi 17). Each cell is the mean of 15 runs after 3 warmup runs on bus.jpg, reported as
-**total (preprocess / inference / postprocess)** in milliseconds. Annotation/plotting is excluded. CPU and GPU
-rows run the default INT8 TFLite assets; QNN runs the `*_qnn.onnx` context binaries on the Hexagon NPU.
+End-to-end `predict()` speeds for the official YOLO26n models on a [Xiaomi 17](https://www.mi.com/) phone powered by the
+Qualcomm [Snapdragon 8 Elite Gen 5](https://www.qualcomm.com/products/mobile/snapdragon/smartphones) (SM8850), which pairs
+a Qualcomm Oryon CPU with an Adreno GPU and the Hexagon NPU (HTP architecture v81). Each cell shows the **total time**
+with the preprocess / inference / postprocess split beneath it.
 
-| Task (imgsz) | CPU | GPU | QNN (NPU) |
-| :-- | :-- | :-- | :-- |
-| Detect (640) | 103.0 (7.7/80.9/14.3) | 28.0 (4.0/8.8/15.2) | **25.2** (3.9/8.2/13.1) |
-| Segment (640) | 100.4 (5.4/83.8/11.1) | 31.7 (3.9/18.1/9.7) | **25.9** (3.9/11.1/10.9) |
-| Semantic (1024) | 74.9 (4.2/51.6/19.1) | **55.1** (5.2/28.9/21.0) | 122.8 (13.0/56.9/52.9) |
-| Classify (224) | 6.4 (1.0/4.8/0.6) | 5.0 (1.9/2.2/0.9) | **2.3** (1.2/0.7/0.3) |
-| Pose (640) | 65.6 (3.9/59.3/2.4) | 15.7 (3.9/9.5/2.3) | **13.4** (3.8/8.2/1.4) |
-| OBB (1024) | 55.5 (3.9/49.5/2.1) | **19.1** (7.4/8.2/3.5) | 30.1 (10.8/15.0/4.2) |
+| Model       | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup>      | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> | NPU Hexagon<br><sup>QNN A16W8<br>(ms)</sup>    |
+| ----------- | -------- | --------------------------- | ------------------------------------------ | -------------------------------------------- | ---------------------------------------------- |
+| YOLO26n     | Detect   | 640                         | 103.0<br><sup>7.7 / 80.9 / 14.3</sup>      | 28.0<br><sup>4.0 / 8.8 / 15.2</sup>           | **25.2**<br><sup>3.9 / 8.2 / 13.1</sup>         |
+| YOLO26n-seg | Segment  | 640                         | 100.4<br><sup>5.4 / 83.8 / 11.1</sup>      | 31.7<br><sup>3.9 / 18.1 / 9.7</sup>           | **25.9**<br><sup>3.9 / 11.1 / 10.9</sup>        |
+| YOLO26n-sem | Semantic | 1024                        | 74.9<br><sup>4.2 / 51.6 / 19.1</sup>       | **55.1**<br><sup>5.2 / 28.9 / 21.0</sup>      | 122.8<sup>1</sup><br><sup>13.0 / 56.9 / 52.9</sup> |
+| YOLO26n-cls | Classify | 224                         | 6.4<br><sup>1.0 / 4.8 / 0.6</sup>          | 5.0<br><sup>1.9 / 2.2 / 0.9</sup>             | **2.3**<br><sup>1.2 / 0.7 / 0.3</sup>           |
+| YOLO26n-pose | Pose    | 640                         | 65.6<br><sup>3.9 / 59.3 / 2.4</sup>        | 15.7<br><sup>3.9 / 9.5 / 2.3</sup>            | **13.4**<br><sup>3.8 / 8.2 / 1.4</sup>          |
+| YOLO26n-obb | OBB      | 1024                        | 55.5<br><sup>3.9 / 49.5 / 2.1</sup>        | **19.1**<br><sup>7.4 / 8.2 / 3.5</sup>        | 30.1<br><sup>10.8 / 15.0 / 4.2</sup>            |
 
-Takeaways:
-
-- The Hexagon NPU (QNN) wins detect, segment, pose, and classify — inference itself runs roughly 6-10x faster
-  than CPU, and pre/postprocessing dominates the remaining wall time.
-- Semantic QNN is currently slower than GPU: the context binary returns full float logits (~20M values at 1024px)
-  that are argmax-decoded on the CPU, while the TFLite graph emits a compact class map. Optimizing this output is
-  tracked as a follow-up.
-- Numbers vary by device generation and thermal state; treat these as relative guidance and benchmark your exact
+- **Speed** values are the full `predict()` time — preprocessing + inference + postprocessing, excluding annotation
+  drawing — as the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg).
+  <br>Reproduce with `flutter test integration_test/qnn_benchmark_test.dart -d <device> --dart-define=RUN_BENCH=true`
+- **CPU** and **GPU** run the default official INT8 TFLite assets the plugin auto-downloads, on LiteRT with
+  `useGpu: false` / `true`. **NPU** runs the `*_v81_qnn.onnx` context binaries (INT8 weights, 16-bit activations) from
+  the same release via the ONNX Runtime QNN Execution Provider.
+- <sup>1</sup> Semantic QNN currently returns full float logits (~20M values at 1024px) that are argmax-decoded on the
+  CPU, while the TFLite graph emits a compact class map — embedding the argmax in the export is a tracked follow-up.
+- Numbers vary with device generation and thermal state; treat them as relative guidance and benchmark your exact
   models on your target hardware.
 
 ## 🎚️ Tune Thresholds

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -30,6 +30,32 @@ Use a simple rule:
 - default app flow: start with `yolo26n`
 - custom production flow: benchmark your exact export on target devices
 
+## 📊 Measured Backend Performance
+
+End-to-end `predict()` times for the official YOLO26n models, measured on a Snapdragon 8 Elite Gen 5 phone
+(Xiaomi 17). Each cell is the mean of 15 runs after 3 warmup runs on bus.jpg, reported as
+**total (preprocess / inference / postprocess)** in milliseconds. Annotation/plotting is excluded. CPU and GPU
+rows run the default INT8 TFLite assets; QNN runs the `*_qnn.onnx` context binaries on the Hexagon NPU.
+
+| Task (imgsz) | CPU | GPU | QNN (NPU) |
+| :-- | :-- | :-- | :-- |
+| Detect (640) | 103.0 (7.7/80.9/14.3) | 28.0 (4.0/8.8/15.2) | **25.2** (3.9/8.2/13.1) |
+| Segment (640) | 100.4 (5.4/83.8/11.1) | 31.7 (3.9/18.1/9.7) | **25.9** (3.9/11.1/10.9) |
+| Semantic (1024) | 74.9 (4.2/51.6/19.1) | **55.1** (5.2/28.9/21.0) | 122.8 (13.0/56.9/52.9) |
+| Classify (224) | 6.4 (1.0/4.8/0.6) | 5.0 (1.9/2.2/0.9) | **2.3** (1.2/0.7/0.3) |
+| Pose (640) | 65.6 (3.9/59.3/2.4) | 15.7 (3.9/9.5/2.3) | **13.4** (3.8/8.2/1.4) |
+| OBB (1024) | 55.5 (3.9/49.5/2.1) | **19.1** (7.4/8.2/3.5) | 30.1 (10.8/15.0/4.2) |
+
+Takeaways:
+
+- The Hexagon NPU (QNN) wins detect, segment, pose, and classify — inference itself runs roughly 6-10x faster
+  than CPU, and pre/postprocessing dominates the remaining wall time.
+- Semantic QNN is currently slower than GPU: the context binary returns full float logits (~20M values at 1024px)
+  that are argmax-decoded on the CPU, while the TFLite graph emits a compact class map. Optimizing this output is
+  tracked as a follow-up.
+- Numbers vary by device generation and thermal state; treat these as relative guidance and benchmark your exact
+  models on your target hardware.
+
 ## 🎚️ Tune Thresholds
 
 Higher confidence thresholds reduce post-processing work and visual noise:

--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -1,0 +1,185 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+// On-device QNN validation + CPU/GPU/QNN benchmark harness (Snapdragon device + network).
+//
+// Validation: loads the v73 QNN context-binary model for every task and checks real outputs on
+// bus.jpg. Benchmark (enable with --dart-define=RUN_BENCH=1): times predict() per task per backend
+// using the native speed (pre + inference + post, no plotting). CPU and GPU rows use the default
+// official int8 TFLite assets (what the app ships); QNN rows use the release context binaries.
+//
+// Run with:
+//   flutter test integration_test/qnn_benchmark_test.dart -d <device> [--dart-define=RUN_BENCH=1]
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:ultralytics_yolo/ultralytics_yolo.dart';
+
+const String _releaseBase =
+    'https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5';
+const bool _runBench = bool.fromEnvironment('RUN_BENCH');
+const bool _runSoak = bool.fromEnvironment('RUN_SOAK');
+
+const Map<String, (String, YOLOTask)> _tasks = {
+  'detect': ('yolo26n', YOLOTask.detect),
+  'segment': ('yolo26n-seg', YOLOTask.segment),
+  'semantic': ('yolo26n-sem', YOLOTask.semantic),
+  'classify': ('yolo26n-cls', YOLOTask.classify),
+  'pose': ('yolo26n-pose', YOLOTask.pose),
+  'obb': ('yolo26n-obb', YOLOTask.obb),
+};
+
+Future<Uint8List> _download(String url) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(Uri.parse(url));
+    final response = await request.close();
+    final builder = BytesBuilder(copy: false);
+    await for (final chunk in response) {
+      builder.add(chunk);
+    }
+    return builder.takeBytes();
+  } finally {
+    client.close();
+  }
+}
+
+Future<Map<String, dynamic>> _predictOnce(
+  String modelPath,
+  YOLOTask task,
+  Uint8List image, {
+  bool useGpu = true,
+}) async {
+  final yolo = YOLO(modelPath: modelPath, task: task, useGpu: useGpu);
+  expect(await yolo.loadModel(), isTrue, reason: '$modelPath should load');
+  final results = await yolo.predict(image);
+  await yolo.dispose();
+  return results;
+}
+
+Future<void> _bench(
+  String label,
+  String modelPath,
+  YOLOTask task,
+  Uint8List image, {
+  bool useGpu = true,
+  int warmup = 3,
+  int runs = 15,
+}) async {
+  final yolo = YOLO(modelPath: modelPath, task: task, useGpu: useGpu);
+  expect(await yolo.loadModel(), isTrue, reason: '$modelPath should load');
+  for (var i = 0; i < warmup; i++) {
+    await yolo.predict(image);
+  }
+  var pre = 0.0, infer = 0.0, post = 0.0, total = 0.0;
+  for (var i = 0; i < runs; i++) {
+    final r = await yolo.predict(image);
+    pre += (r['preMs'] as num?)?.toDouble() ?? 0.0;
+    infer += (r['inferenceMs'] as num?)?.toDouble() ?? 0.0;
+    post += (r['postMs'] as num?)?.toDouble() ?? 0.0;
+    total += (r['speed'] as num?)?.toDouble() ?? 0.0;
+  }
+  // ignore: avoid_print
+  print(
+    'BENCH|$label|${(pre / runs).toStringAsFixed(1)}|'
+    '${(infer / runs).toStringAsFixed(1)}|${(post / runs).toStringAsFixed(1)}|'
+    '${(total / runs).toStringAsFixed(1)}',
+  );
+  await yolo.dispose();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'QNN models run on the NPU for all six tasks',
+    (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        final image = await _download('https://ultralytics.com/images/bus.jpg');
+
+        for (final entry in _tasks.entries) {
+          final (id, task) = entry.value;
+          final results = await _predictOnce(
+            '$_releaseBase/${id}_v73_qnn.onnx',
+            task,
+            image,
+          );
+          final detections =
+              (results['detections'] as List?)?.cast<Map>() ?? [];
+          final classes = detections.map((d) => d['className']).toSet();
+          // ignore: avoid_print
+          print(
+            'QNN ${entry.key}: ${detections.length} detections classes=$classes '
+            'keys=${results.keys.toList()} '
+            'pre=${results['preMs']} infer=${results['inferenceMs']} post=${results['postMs']}',
+          );
+          switch (entry.key) {
+            case 'detect' || 'segment':
+              expect(classes, containsAll(['bus', 'person']));
+            case 'pose':
+              expect(detections, isNotEmpty);
+            case 'classify':
+              expect(results.containsKey('detections'), isTrue);
+            case 'semantic':
+              expect(results.containsKey('semanticMask'), isTrue);
+            case 'obb':
+              // DOTA aerial classes won't fire on bus.jpg; a clean run is the assertion
+              expect(results, isA<Map<String, dynamic>>());
+          }
+        }
+      });
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+
+  testWidgets(
+    'soak: sustained inference does not exhaust memory',
+    (WidgetTester tester) async {
+      if (!_runSoak) {
+        return;
+      }
+      await tester.runAsync(() async {
+        final image = await _download('https://ultralytics.com/images/bus.jpg');
+        // Worst case: semantic logits are the largest output tensors in the model zoo.
+        final yolo = YOLO(
+          modelPath: '$_releaseBase/yolo26n-sem_v73_qnn.onnx',
+          task: YOLOTask.semantic,
+        );
+        expect(await yolo.loadModel(), isTrue);
+        for (var i = 0; i < 150; i++) {
+          await yolo.predict(image);
+          if (i % 25 == 0) {
+            // ignore: avoid_print
+            print('SOAK|$i');
+          }
+        }
+        await yolo.dispose();
+        // ignore: avoid_print
+        print('SOAK|done');
+      });
+    },
+    timeout: const Timeout(Duration(minutes: 30)),
+  );
+
+  testWidgets('benchmark CPU vs GPU vs QNN', (WidgetTester tester) async {
+    if (!_runBench) {
+      return;
+    }
+    await tester.runAsync(() async {
+      final image = await _download('https://ultralytics.com/images/bus.jpg');
+      for (final entry in _tasks.entries) {
+        final (id, task) = entry.value;
+        await _bench('${entry.key}|cpu', id, task, image, useGpu: false);
+        await _bench('${entry.key}|gpu', id, task, image);
+        await _bench(
+          '${entry.key}|qnn',
+          '$_releaseBase/${id}_v81_qnn.onnx',
+          task,
+          image,
+        );
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 30)));
+}

--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -137,7 +137,7 @@ void main() {
   testWidgets(
     'soak: sustained inference does not exhaust memory',
     (WidgetTester tester) async {
-      if (!_runSoak) {
+      if (!_runSoak || !Platform.isAndroid) {
         return;
       }
       await tester.runAsync(() async {
@@ -171,14 +171,20 @@ void main() {
       final image = await _download('https://ultralytics.com/images/bus.jpg');
       for (final entry in _tasks.entries) {
         final (id, task) = entry.value;
+        // CPU on both platforms (Android: LiteRT CPU; iOS: Core ML .cpuOnly)
         await _bench('${entry.key}|cpu', id, task, image, useGpu: false);
-        await _bench('${entry.key}|gpu', id, task, image);
-        await _bench(
-          '${entry.key}|qnn',
-          '$_releaseBase/${id}_v81_qnn.onnx',
-          task,
-          image,
-        );
+        if (Platform.isAndroid) {
+          await _bench('${entry.key}|gpu', id, task, image);
+          await _bench(
+            '${entry.key}|qnn',
+            '$_releaseBase/${id}_v81_qnn.onnx',
+            task,
+            image,
+          );
+        } else {
+          // iOS useGpu:true = Core ML .cpuAndNeuralEngine (ANE)
+          await _bench('${entry.key}|ane', id, task, image);
+        }
       }
     });
   }, timeout: const Timeout(Duration(minutes: 30)));

--- a/lib/widgets/performance_label.dart
+++ b/lib/widgets/performance_label.dart
@@ -15,14 +15,26 @@ class PerformanceLabel extends StatelessWidget {
   /// Smoothed frames-per-second from [YOLOPerformanceMetrics].
   final double fps;
 
-  /// Per-inference time in milliseconds.
+  /// Total per-frame processing time in milliseconds (pre + inference + post).
   final double inferenceMs;
+
+  /// Preprocessing time in milliseconds, shown in the breakdown line when > 0.
+  final double preMs;
+
+  /// Model inference time in milliseconds.
+  final double modelMs;
+
+  /// Postprocessing time in milliseconds.
+  final double postMs;
 
   const PerformanceLabel({
     super.key,
     required this.modelName,
     required this.fps,
     required this.inferenceMs,
+    this.preMs = 0,
+    this.modelMs = 0,
+    this.postMs = 0,
   });
 
   @override
@@ -50,6 +62,16 @@ class PerformanceLabel extends StatelessWidget {
             fontWeight: FontWeight.w400,
           ),
         ),
+        if (preMs + modelMs + postMs > 0)
+          Text(
+            '${preMs.toStringAsFixed(1)} pre · ${modelMs.toStringAsFixed(1)} inference · ${postMs.toStringAsFixed(1)} post',
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 12,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
       ],
     );
   }

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -88,10 +88,10 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
   // High-frequency values driven by native event streams (zoom/lens) and per-inference-frame metrics. These are
   // ValueNotifiers — NOT setState fields — so updating them rebuilds only the small leaf widgets that display them
   // (FPS/ms line, zoom HUD, lens highlight) instead of the whole tree (camera platform view + every control) ~30x/sec.
-  final ValueNotifier<({double fps, double ms})> _metrics = ValueNotifier((
-    fps: 0,
-    ms: 0,
-  ));
+  final ValueNotifier<
+    ({double fps, double ms, double pre, double infer, double post})
+  >
+  _metrics = ValueNotifier((fps: 0, ms: 0, pre: 0, infer: 0, post: 0));
   final ValueNotifier<double> _zoom = ValueNotifier(1);
   final ValueNotifier<String> _lensLabel = ValueNotifier('');
 
@@ -640,7 +640,13 @@ class _YOLOShowcaseState extends State<YOLOShowcase> {
   void _onPerformanceMetrics(YOLOPerformanceMetrics metrics) {
     // Update the notifier, NOT setState: this fires every inference frame (~30 fps). A setState here rebuilt the whole
     // tree — camera platform view and all controls — 30x/sec, which was the primary source of the lag.
-    _metrics.value = (fps: metrics.fps, ms: metrics.processingTimeMs);
+    _metrics.value = (
+      fps: metrics.fps,
+      ms: metrics.processingTimeMs,
+      pre: metrics.preMs,
+      infer: metrics.inferenceMs,
+      post: metrics.postMs,
+    );
   }
 
   static String _taskLabel(YOLOTask task) {
@@ -898,7 +904,10 @@ class _ShowcaseOverlay extends StatelessWidget {
   });
 
   final String modelName;
-  final ValueListenable<({double fps, double ms})> metrics;
+  final ValueListenable<
+    ({double fps, double ms, double pre, double infer, double post})
+  >
+  metrics;
   final YOLOTask task;
   final String size;
   final Set<String> availableSizes;
@@ -1038,12 +1047,17 @@ class _ShowcaseOverlay extends StatelessWidget {
   Widget _topControls() {
     return Column(
       children: [
-        ValueListenableBuilder<({double fps, double ms})>(
+        ValueListenableBuilder<
+          ({double fps, double ms, double pre, double infer, double post})
+        >(
           valueListenable: metrics,
           builder: (context, m, _) => PerformanceLabel(
             modelName: modelName,
             fps: m.fps,
             inferenceMs: m.ms,
+            preMs: m.pre,
+            modelMs: m.infer,
+            postMs: m.post,
           ),
         ),
         const SizedBox(height: _topGap),

--- a/lib/yolo_performance_metrics.dart
+++ b/lib/yolo_performance_metrics.dart
@@ -16,6 +16,15 @@ class YOLOPerformanceMetrics {
   /// but excludes camera capture and UI rendering time.
   final double processingTimeMs;
 
+  /// Preprocessing time (letterbox + normalization) in milliseconds.
+  final double preMs;
+
+  /// Model inference time in milliseconds.
+  final double inferenceMs;
+
+  /// Postprocessing time (decode + NMS/masks) in milliseconds.
+  final double postMs;
+
   /// Sequential frame number since detection started.
   ///
   /// Useful for tracking dropped frames or debugging timing issues.
@@ -34,6 +43,9 @@ class YOLOPerformanceMetrics {
     required this.processingTimeMs,
     required this.frameNumber,
     required this.timestamp,
+    this.preMs = 0.0,
+    this.inferenceMs = 0.0,
+    this.postMs = 0.0,
   });
 
   /// Creates performance metrics from a raw data map.
@@ -48,6 +60,9 @@ class YOLOPerformanceMetrics {
       processingTimeMs: (data['processingTimeMs'] as num?)?.toDouble() ?? 0.0,
       frameNumber: (data['frameNumber'] as num?)?.toInt() ?? 0,
       timestamp: DateTime.now(), // Use current time as fallback
+      preMs: (data['preMs'] as num?)?.toDouble() ?? 0.0,
+      inferenceMs: (data['inferenceMs'] as num?)?.toDouble() ?? 0.0,
+      postMs: (data['postMs'] as num?)?.toDouble() ?? 0.0,
     );
   }
 
@@ -60,6 +75,9 @@ class YOLOPerformanceMetrics {
       'processingTimeMs': processingTimeMs,
       'frameNumber': frameNumber,
       'timestamp': timestamp.millisecondsSinceEpoch,
+      'preMs': preMs,
+      'inferenceMs': inferenceMs,
+      'postMs': postMs,
     };
   }
 
@@ -83,12 +101,18 @@ class YOLOPerformanceMetrics {
     double? processingTimeMs,
     int? frameNumber,
     DateTime? timestamp,
+    double? preMs,
+    double? inferenceMs,
+    double? postMs,
   }) {
     return YOLOPerformanceMetrics(
       fps: fps ?? this.fps,
       processingTimeMs: processingTimeMs ?? this.processingTimeMs,
       frameNumber: frameNumber ?? this.frameNumber,
       timestamp: timestamp ?? this.timestamp,
+      preMs: preMs ?? this.preMs,
+      inferenceMs: inferenceMs ?? this.inferenceMs,
+      postMs: postMs ?? this.postMs,
     );
   }
 


### PR DESCRIPTION
## Timing breakdown + measured backend performance

Stacked on #526. Adds permanent per-stage timing to the inference pipeline and documents measured backend performance.

### Timing breakdown (permanent feature)
- Every Android predictor now reports **preprocess / inference / postprocess** times alongside the existing total (annotation/plotting excluded from all timings)
- Exposed through `YOLOResult`, the single-image `predict()` response (`preMs`/`inferenceMs`/`postMs`), the camera-stream metrics map, and `YOLOPerformanceMetrics`
- `PerformanceLabel` HUD shows the breakdown as a smaller line under the existing `FPS - total ms` line; it hides automatically when values are zero (e.g. iOS until ultralytics/yolo-ios-app ships matching fields — parity PR to follow there)

### Benchmarks (doc/performance.md)
All six YOLO26n tasks on a Snapdragon 8 Elite Gen 5: default INT8 TFLite on CPU/GPU vs QNN context binaries on the Hexagon NPU. QNN wins detect/segment/pose/classify (inference ~6-10x over CPU); semantic QNN is slower due to CPU argmax over float logits (follow-up noted in the doc). GPU rows verified as real Adreno execution via logcat.

### Soak test
150 sustained semantic predicts with flat PSS (819-1010MB GC sawtooth, no upward trend) — regression-protects the output-buffer reuse fix in #526. The benchmark/soak harness is committed as an opt-in integration test (`--dart-define=RUN_BENCH=true` / `RUN_SOAK=true`, not run in CI).

### Testing
- `flutter analyze` clean, 173 Dart tests pass, Kotlin unit tests pass, example APK builds
- All timing fields validated live on-device (values in the PR's benchmark table came through this plumbing)