### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The main goal is simple integration: use an official model ID, or drop in your o
 
 <div align="center">
   <br>
-  <a href="https://apps.apple.com/us/app/idetection/id1452689527" target="_blank"><img width="100%" src="https://github.com/user-attachments/assets/d5dab2e7-f473-47ce-bc63-69bef89ba52a" alt="Ultralytics YOLO iOS App previews"></a>
+  <a href="https://apps.apple.com/us/app/ultralytics-yolo/id1452689527" target="_blank"><img width="100%" src="https://github.com/user-attachments/assets/d5dab2e7-f473-47ce-bc63-69bef89ba52a" alt="Ultralytics YOLO iOS App previews"></a>
   <br>
   <br>
-  <a href="https://apps.apple.com/us/app/idetection/id1452689527" style="text-decoration:none;">
+  <a href="https://apps.apple.com/us/app/ultralytics-yolo/id1452689527" style="text-decoration:none;">
     <img src="https://raw.githubusercontent.com/ultralytics/assets/main/app/app-store.svg" width="15%" alt="Apple App store"></a>
   &nbsp;&nbsp;
   <a href="https://play.google.com/store/apps/details?id=com.ultralytics.yolo" style="text-decoration:none;">
@@ -61,7 +61,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.5.1
+  ultralytics_yolo: ^0.6.2
 ```
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,10 +21,10 @@ Ultralytics YOLO Flutter 是官方 Flutter 插件，用于在 iOS 和 Android �
 
 <div align="center">
   <br>
-  <a href="https://apps.apple.com/us/app/idetection/id1452689527" target="_blank"><img width="100%" src="https://github.com/user-attachments/assets/d5dab2e7-f473-47ce-bc63-69bef89ba52a" alt="Ultralytics YOLO iOS App previews"></a>
+  <a href="https://apps.apple.com/us/app/ultralytics-yolo/id1452689527" target="_blank"><img width="100%" src="https://github.com/user-attachments/assets/d5dab2e7-f473-47ce-bc63-69bef89ba52a" alt="Ultralytics YOLO iOS App previews"></a>
   <br>
   <br>
-  <a href="https://apps.apple.com/us/app/idetection/id1452689527" style="text-decoration:none;">
+  <a href="https://apps.apple.com/us/app/ultralytics-yolo/id1452689527" style="text-decoration:none;">
     <img src="https://raw.githubusercontent.com/ultralytics/assets/main/app/app-store.svg" width="15%" alt="Apple App store"></a>
   &nbsp;&nbsp;
   <a href="https://play.google.com/store/apps/details?id=com.ultralytics.yolo" style="text-decoration:none;">
@@ -61,7 +61,7 @@ Ultralytics YOLO Flutter 是官方 Flutter 插件，用于在 iOS 和 Android �
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.5.1
+  ultralytics_yolo: ^0.6.2
 ```
 
 ```bash

--- a/play-store-assets/README.md
+++ b/play-store-assets/README.md
@@ -15,8 +15,8 @@ Useful links:
 
 Before building store assets:
 
-- `pubspec.yaml` must have the package version, for example `0.5.1`.
-- `example/pubspec.yaml` must have the matching app version plus Android build number, for example `0.5.1+5`.
+- `pubspec.yaml` must have the package version, for example `0.6.2`.
+- `example/pubspec.yaml` must have the matching app version plus Android build number, for example `0.6.2+8`.
 - `CHANGELOG.md` must have a top section for that version.
 - Local signing files must be present:
   - `example/android/key.properties`


### PR DESCRIPTION
## Summary
- updates the top-level README install snippet to the current pub.dev package version
- replaces the stale App Store slug with the current Ultralytics YOLO app URL
- mirrors the same top-level fixes in the existing Chinese README
- updates the Play Store staging README version examples to the current package and example app versions

## Validation
- git diff --check
- lychee README.md README.zh-CN.md example/README.md example/test/README.md ios/Classes/README.md play-store-assets/README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR refreshes project documentation and store metadata to reflect the latest `ultralytics_yolo` release and updated iOS App Store listing.

### 📊 Key Changes
- 🔗 Updated iOS App Store links in both `README.md` and `README.zh-CN.md` from the old `idetection` URL to the current **Ultralytics YOLO** app URL.
- 📦 Bumped the documented Flutter package dependency version from `ultralytics_yolo: ^0.5.1` to `ultralytics_yolo: ^0.6.2` in both English and Chinese READMEs.
- 🏪 Updated `play-store-assets/README.md` version examples:
  - package version example changed from `0.5.1` to `0.6.2`
  - example app version/build number changed from `0.5.1+5` to `0.6.2+8`

### 🎯 Purpose & Impact
- ✅ Keeps documentation aligned with the latest published plugin version, reducing confusion for developers integrating the Flutter package.
- 📱 Ensures users and contributors are directed to the correct iOS app listing, improving discoverability and avoiding broken or outdated references.
- 🛠️ Helps maintainers prepare app store assets with up-to-date versioning examples, making release workflows clearer and more consistent.
- 🌍 Improves consistency across both English and Chinese documentation, which benefits a broader user community.