### PR TITLE
Use SystemBarStyle instead of deprecated window color setters

### DIFF
--- a/example/android/app/src/main/kotlin/com/ultralytics/yolo/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/ultralytics/yolo/MainActivity.kt
@@ -3,21 +3,20 @@
 package com.ultralytics.yolo
 
 import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import io.flutter.embedding.android.FlutterFragmentActivity
 
 class MainActivity : FlutterFragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
-        window.navigationBarColor = Color.TRANSPARENT
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            window.navigationBarDividerColor = Color.TRANSPARENT
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            window.isNavigationBarContrastEnforced = false
-        }
+        // Android 15 deprecates the Window system-bar color setters. SystemBarStyle makes both bars
+        // transparent through the supported API on every Android version (and disables the navigation
+        // bar contrast scrim where it applies).
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
+        )
         super.onCreate(savedInstanceState)
     }
 }

--- a/example/android/app/src/main/kotlin/com/ultralytics/yolo/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/ultralytics/yolo/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : FlutterFragmentActivity() {
         // transparent through the supported API on every Android version (and disables the navigation
         // bar contrast scrim where it applies).
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
         )
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
Play Console flags the 0.6.2 release for deprecated edge-to-edge APIs on Android 15 / SDK 35 targets: `Window.setNavigationBarColor` and `Window.setNavigationBarDividerColor`, both called from `MainActivity.onCreate`.

`enableEdgeToEdge` already runs there; this replaces the raw window setters with `SystemBarStyle` arguments, which configure the same transparent system bars through the supported API on every Android version and disable the navigation bar contrast scrim where it applies.

The remaining APIs in the Play report (`setStatusBarColor`, `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`) originate in the Flutter engine, not app code, and track with Flutter version updates.

Verified: debug APK builds; the showcase UI already lays out with safe-area insets under edge-to-edge.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ Updated the Android example app to use the modern edge-to-edge system bar API, improving compatibility with newer Android versions like Android 15.

### 📊 Key Changes
- Replaced manual `window` system bar styling in `MainActivity.kt` with `enableEdgeToEdge(...)` using `SystemBarStyle.auto(...)`.
- Removed older version-specific checks for:
  - navigation bar divider color
  - navigation bar contrast enforcement
  - deprecated system bar color setters
- Kept both the status bar and navigation bar transparent through a single supported AndroidX API.
- Added an in-code comment explaining that this change addresses Android 15 deprecations and handles transparency consistently across Android versions.

### 🎯 Purpose & Impact
- 📱 Ensures the Flutter Android example follows the recommended Android approach for edge-to-edge UI.
- ✅ Improves forward compatibility by avoiding deprecated system bar APIs on Android 15.
- 🧹 Simplifies the activity setup by removing conditional OS-version handling.
- 🎨 Preserves the app’s transparent system bar appearance for a cleaner, more modern fullscreen experience across devices.