### PR TITLE
Add opt-in camera analysis resolution for Android YOLOView

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -152,7 +152,9 @@ class YOLOPlatformView(
                 maxFPS = (streamingConfigParam["maxFPS"] as? Number)?.toInt(),
                 throttleIntervalMs = (streamingConfigParam["throttleIntervalMs"] as? Number)?.toInt(),
                 inferenceFrequency = (streamingConfigParam["inferenceFrequency"] as? Number)?.toInt(),
-                skipFrames = (streamingConfigParam["skipFrames"] as? Number)?.toInt()
+                skipFrames = (streamingConfigParam["skipFrames"] as? Number)?.toInt(),
+                analysisWidth = (streamingConfigParam["analysisWidth"] as? Number)?.toInt(),
+                analysisHeight = (streamingConfigParam["analysisHeight"] as? Number)?.toInt()
             )
         } else {
             // Create default config when no streaming config is provided
@@ -424,7 +426,9 @@ class YOLOPlatformView(
                             maxFPS = (configMap["maxFPS"] as? Number)?.toInt(),
                             throttleIntervalMs = (configMap["throttleIntervalMs"] as? Number)?.toInt(),
                             inferenceFrequency = (configMap["inferenceFrequency"] as? Number)?.toInt(),
-                            skipFrames = (configMap["skipFrames"] as? Number)?.toInt()
+                            skipFrames = (configMap["skipFrames"] as? Number)?.toInt(),
+                            analysisWidth = (configMap["analysisWidth"] as? Number)?.toInt(),
+                            analysisHeight = (configMap["analysisHeight"] as? Number)?.toInt()
                         )
                         yoloView.setStreamConfig(streamConfig)
                         result.success(null)

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOStreamConfig.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOStreamConfig.kt
@@ -27,7 +27,12 @@ data class YOLOStreamConfig(
     
     // Inference frequency controls
     val inferenceFrequency: Int? = null,  // Target inference frequency in FPS (e.g., 5, 10, 15, 30)
-    val skipFrames: Int? = null           // Skip frames between inferences (alternative to inferenceFrequency)
+    val skipFrames: Int? = null,          // Skip frames between inferences (alternative to inferenceFrequency)
+
+    // Requested CameraX analysis resolution; null keeps the CameraX default (~640x480). The camera
+    // falls back to the nearest supported size, so any request is safe on any device.
+    val analysisWidth: Int? = null,
+    val analysisHeight: Int? = null
     
     // Note: annotatedImage is intentionally excluded for YOLOView
     // YOLOView uses Canvas drawing (real-time overlay), not bitmap generation

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -793,7 +793,7 @@ class YOLOView @JvmOverloads constructor(
                         .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
                     val analysisWidth = streamConfig?.analysisWidth
                     val analysisHeight = streamConfig?.analysisHeight
-                    if (analysisWidth != null && analysisHeight != null) {
+                    if (analysisWidth != null && analysisHeight != null && analysisWidth > 0 && analysisHeight > 0) {
                         // Opt-in higher analysis resolution: by default CameraX delivers ~640x480 frames, which caps
                         // the detail reaching models with larger inputs. CameraX picks the nearest supported size.
                         analysisBuilder.setResolutionSelector(
@@ -807,6 +807,9 @@ class YOLOView @JvmOverloads constructor(
                                 .build()
                         )
                     } else {
+                        if (analysisWidth != null || analysisHeight != null) {
+                            Log.w(TAG, "Ignoring invalid analysisResolution ${analysisWidth}x${analysisHeight}")
+                        }
                         analysisBuilder.setTargetAspectRatio(AspectRatio.RATIO_4_3)
                     }
                     imageAnalysisUseCase = analysisBuilder.build()

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -18,6 +18,8 @@ import android.os.Build
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.*
 import androidx.camera.core.Camera
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import android.util.SizeF
@@ -179,8 +181,13 @@ class YOLOView @JvmOverloads constructor(
     
     /** Set streaming configuration */
     fun setStreamConfig(config: YOLOStreamConfig?) {
+        val resolutionChanged = config?.analysisWidth != streamConfig?.analysisWidth ||
+            config?.analysisHeight != streamConfig?.analysisHeight
         this.streamConfig = config
         setupThrottlingFromConfig()
+        if (resolutionChanged && camera != null) {
+            startCamera() // rebind so the new analysis resolution takes effect
+        }
     }
 
     /** Set streaming callback */
@@ -778,14 +785,31 @@ class YOLOView @JvmOverloads constructor(
                         .setTargetRotation(targetRotation)
                         .build()
 
-                    imageAnalysisUseCase = ImageAnalysis.Builder()
+                    val analysisBuilder = ImageAnalysis.Builder()
                         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                        .setTargetAspectRatio(AspectRatio.RATIO_4_3)
                         .setTargetRotation(targetRotation)
                         // Ask CameraX for RGBA frames so toBitmap() is a direct buffer copy. The default YUV_420_888
                         // forced a per-frame JPEG encode@100 + decode round-trip (~100ms/frame, ~5 FPS).
                         .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
-                        .build()
+                    val analysisWidth = streamConfig?.analysisWidth
+                    val analysisHeight = streamConfig?.analysisHeight
+                    if (analysisWidth != null && analysisHeight != null) {
+                        // Opt-in higher analysis resolution: by default CameraX delivers ~640x480 frames, which caps
+                        // the detail reaching models with larger inputs. CameraX picks the nearest supported size.
+                        analysisBuilder.setResolutionSelector(
+                            ResolutionSelector.Builder()
+                                .setResolutionStrategy(
+                                    ResolutionStrategy(
+                                        android.util.Size(analysisWidth, analysisHeight),
+                                        ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
+                                    )
+                                )
+                                .build()
+                        )
+                    } else {
+                        analysisBuilder.setTargetAspectRatio(AspectRatio.RATIO_4_3)
+                    }
+                    imageAnalysisUseCase = analysisBuilder.build()
 
                     cameraExecutor = Executors.newSingleThreadExecutor()
                     val myGeneration = cameraGeneration.incrementAndGet()

--- a/lib/widgets/yolo_controller.dart
+++ b/lib/widgets/yolo_controller.dart
@@ -223,6 +223,8 @@ class YOLOViewController {
         'throttleIntervalMs': config.throttleInterval?.inMilliseconds,
         'inferenceFrequency': config.inferenceFrequency,
         'skipFrames': config.skipFrames,
+        'analysisWidth': config.analysisResolution?.width.round(),
+        'analysisHeight': config.analysisResolution?.height.round(),
       });
 
   Future<void> stop() => _invoke('stop');

--- a/lib/yolo_streaming_config.dart
+++ b/lib/yolo_streaming_config.dart
@@ -1,5 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import 'dart:ui' show Size;
+
 /// Configuration class for customizing YOLO streaming behavior.
 ///
 /// This class allows fine-grained control over what data is included in
@@ -112,6 +114,21 @@ class YOLOStreamingConfig {
   /// `skipFrames` takes precedence.
   final int? skipFrames;
 
+  /// Requested camera analysis resolution (Android only).
+  ///
+  /// By default CameraX delivers analysis frames at its default size
+  /// (typically 640x480), which caps the detail available to models with
+  /// larger inputs - small objects can be lost to the upscale. Set this to
+  /// request a higher analysis resolution, e.g. `Size(1280, 960)` for an
+  /// 800px model. The camera falls back to the nearest supported size, and
+  /// detection coordinates are normalized so overlays are unaffected.
+  ///
+  /// Higher resolutions increase the per-frame copy and downscale cost, so
+  /// leave this null (the default) unless small-object detail matters more
+  /// than peak FPS. iOS analysis frames already track the capture session
+  /// resolution and ignore this setting.
+  final Size? analysisResolution;
+
   /// Creates a YOLOStreamingConfig with custom settings.
   ///
   /// This constructor allows full customization of streaming behavior.
@@ -129,6 +146,7 @@ class YOLOStreamingConfig {
     this.throttleInterval,
     this.inferenceFrequency,
     this.skipFrames,
+    this.analysisResolution,
   });
 
   /// Creates a minimal configuration optimized for maximum performance.
@@ -155,7 +173,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a custom configuration with specified parameters.
   ///
@@ -182,6 +201,7 @@ class YOLOStreamingConfig {
     this.throttleInterval,
     this.inferenceFrequency,
     this.skipFrames,
+    this.analysisResolution,
   }) : includeDetections = includeDetections ?? true,
        includeClassifications = includeClassifications ?? true,
        includeProcessingTimeMs = includeProcessingTimeMs ?? true,
@@ -209,7 +229,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a configuration with pose keypoints.
   ///
@@ -229,7 +250,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a full configuration with all data included.
   ///
@@ -255,7 +277,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a debug configuration with all data and images.
   ///
@@ -278,7 +301,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a throttled configuration with specified FPS limit.
   ///
@@ -387,6 +411,7 @@ class YOLOStreamingConfig {
         'maxFPS: $maxFPS, '
         'throttleInterval: ${throttleInterval?.inMilliseconds}ms, '
         'inferenceFrequency: $inferenceFrequency, '
-        'skipFrames: $skipFrames)';
+        'skipFrames: $skipFrames, '
+        'analysisResolution: $analysisResolution)';
   }
 }

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -489,6 +489,11 @@ class _YOLOViewState extends State<YOLOView> {
       if (widget.streamingConfig!.skipFrames != null) {
         streamConfig['skipFrames'] = widget.streamingConfig!.skipFrames;
       }
+      final analysisResolution = widget.streamingConfig!.analysisResolution;
+      if (analysisResolution != null) {
+        streamConfig['analysisWidth'] = analysisResolution.width.round();
+        streamConfig['analysisHeight'] = analysisResolution.height.round();
+      }
 
       creationParams['streamingConfig'] = streamConfig;
     }

--- a/test/yolo_view_test.dart
+++ b/test/yolo_view_test.dart
@@ -342,6 +342,7 @@ void main() {
                 throttleInterval: Duration(milliseconds: 120),
                 inferenceFrequency: 3,
                 skipFrames: 2,
+                analysisResolution: Size(1280, 960),
               ),
               onResult: results.addAll,
               onPerformanceMetrics: metrics.add,
@@ -376,6 +377,8 @@ void main() {
           'throttleIntervalMs': 120,
           'inferenceFrequency': 3,
           'skipFrames': 2,
+          'analysisWidth': 1280,
+          'analysisHeight': 960,
         });
         expect(loadedModels, ['camera_model.tflite']);
 


### PR DESCRIPTION
Fixes #529.

On Android the live `YOLOView` built its CameraX `ImageAnalysis` with only `setTargetAspectRatio(RATIO_4_3)`, so analysis frames arrived at the CameraX default (~640x480) regardless of model input size — an 800px model never saw more than 640x480 worth of pixels, a real ceiling for small-object detection.

This adds the opt-in resolution proposed in the issue:

- `YOLOStreamingConfig.analysisResolution` (`Size?`, default null = today's behavior)
- flows through view creation params and the runtime `setStreamingConfig` channel
- when set, the `ImageAnalysis` is built with a `ResolutionSelector` using closest-higher-then-lower fallback, so any request is safe on any device
- a runtime config change rebinds the camera so the new resolution takes effect
- detections remain normalized against the analysis frame, so overlay coordinates are unaffected; model input size is fixed, so inference cost is unchanged (only the per-frame copy/downscale scales with the request)

iOS analysis frames already track the capture session resolution (720p default) and ignore the setting; the symmetric iOS-SDK option for >720p models is ultralytics/yolo-ios-app#277.

Verified: `flutter analyze` clean, all 173 tests pass (creation-params test extended), plugin Kotlin compiles.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds configurable camera analysis resolution on Android 📷, letting Flutter apps request higher-quality frames for YOLO inference when small-object detail matters.

### 📊 Key Changes
- Added a new `analysisResolution` option to `YOLOStreamingConfig` in Flutter, represented as a `Size`.
- Passed `analysisWidth` and `analysisHeight` from Flutter to the Android native layer during view creation and runtime config updates.
- Extended Android `YOLOStreamConfig` to store requested analysis resolution values.
- Updated Android `YOLOView` to apply the requested resolution through CameraX `ResolutionSelector` and `ResolutionStrategy`.
- Added logic to restart/rebind the camera automatically when the analysis resolution changes, so updates take effect immediately 🔄.
- Kept safe fallback behavior: if the requested resolution is invalid or unsupported, CameraX falls back to the closest supported size or default behavior.
- Added test coverage to verify the new resolution parameters are included in the platform config ✅.

### 🎯 Purpose & Impact
- Improves detection quality for small or distant objects by allowing higher-resolution analysis frames 🔍.
- Gives developers more control over the tradeoff between accuracy and performance, since higher resolutions can reduce FPS but provide more visual detail.
- Preserves compatibility across Android devices because CameraX safely chooses the nearest supported resolution.
- Keeps overlays and detection rendering stable, since detection coordinates remain normalized.
- Has no major effect on iOS behavior, as this new setting is Android-only 📱.