### PR TITLE
Bridge per-stage timing from the iOS SDK

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,8 +13,8 @@ PODS:
     - FlutterMacOS
   - ultralytics_yolo (0.6.0):
     - Flutter
-    - UltralyticsYOLO (< 9.0, >= 8.9.4)
-  - UltralyticsYOLO (8.9.4)
+    - UltralyticsYOLO (< 9.0, >= 8.9.5)
+  - UltralyticsYOLO (8.9.5)
   - url_launcher_ios (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
@@ -62,8 +62,8 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  ultralytics_yolo: b19941dc12a47245d2db81462d4734ac1273e2c8
-  UltralyticsYOLO: 163cd55ce4e0282ebc0d5712dd098d1897d04d7d
+  ultralytics_yolo: 3bab5f36454be0b835aaef0b4445126088e0bdcf
+  UltralyticsYOLO: 2efe21f551e8fdd5c46716bc3461b5aded4a76af
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 

--- a/ios/Classes/YOLOInstanceManager.swift
+++ b/ios/Classes/YOLOInstanceManager.swift
@@ -473,8 +473,11 @@ class YOLOInstanceManager {
       }
     }
 
-    // Include speed metric
-    resultDict["speed"] = result.speed
+    // Include timing: total speed plus the pre/inference/post breakdown (milliseconds)
+    resultDict["speed"] = result.speed * 1000  // align with Android: milliseconds
+    resultDict["preMs"] = result.preMs
+    resultDict["inferenceMs"] = result.inferenceMs
+    resultDict["postMs"] = result.postMs
 
     return resultDict
   }

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -2079,6 +2079,9 @@ extension YOLOView {
     // Add performance metrics (if enabled)
     if config.includeProcessingTimeMs {
       map["processingTimeMs"] = result.speed * 1000
+      map["preMs"] = result.preMs
+      map["inferenceMs"] = result.inferenceMs
+      map["postMs"] = result.postMs
     }
 
     if config.includeFps {

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -17,7 +17,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # `no rule to process file ... net.daringfireball.markdown` warning on every Xcode build.
   s.source_files = 'Classes/**/*.{swift,h,m}'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.4', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.5', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
Completes the timing-breakdown effort on the plugin's iOS side, now that UltralyticsYOLO 8.9.5 is published:

- Maps `preMs`/`inferenceMs`/`postMs` from the SDK's `YOLOResult` into single-image predict results and the camera stream, matching the Android keys.
- Fixes single-image `speed` to milliseconds — `predictOnImage` returns seconds, while Android reports ms; consumers previously saw a 1000x discrepancy between platforms.
- Bumps the podspec dependency floor to `>= 8.9.5` (the first release carrying the per-stage timing API) and resolves it in the example lockfile.

Verified: example app builds for the iOS simulator against the published 8.9.5 pod (no local overrides), `flutter analyze` clean, all Dart tests pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📱 This PR improves iOS performance reporting in the Flutter app by exposing more detailed timing metrics and updating the iOS YOLO dependency to a newer version.

### 📊 Key Changes
- Added **detailed timing fields** to iOS result output:
  - `preMs`
  - `inferenceMs`
  - `postMs`
- Updated the existing `speed` value on iOS to be reported in **milliseconds**, aligning it with Android behavior.
- Extended `YOLOView.swift` so that when processing-time reporting is enabled, the app now includes:
  - total processing time
  - preprocessing time
  - inference time
  - postprocessing time
- Bumped the iOS CocoaPods dependency from **`UltralyticsYOLO >= 8.9.4`** to **`>= 8.9.5`**.
- Regenerated related iOS lockfile data in `example/ios/Podfile.lock` to reflect the dependency update.

### 🎯 Purpose & Impact
- ✅ **Improves cross-platform consistency** by making iOS timing output match Android units more closely.
- 🔍 **Gives developers better visibility into model performance** by breaking processing time into key stages instead of showing only a single total value.
- 🚀 **Makes debugging and optimization easier**, since users can now see whether delays come from preprocessing, inference, or postprocessing.
- 📦 **Ensures compatibility with the latest iOS YOLO native library updates** through the dependency bump.
- 👥 For app developers and users, this means **more accurate performance insights** and potentially smoother monitoring of real-time YOLO-powered experiences on iOS.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `example/ios/Podfile.lock`
</details>
