### PR TITLE
0.6.4 - Android analysis resolution and iOS timing bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.6.4
+
+- **Feature**: Opt-in camera analysis resolution on Android — `YOLOStreamingConfig.analysisResolution` requests a
+  higher CameraX analysis size (with closest-size fallback) so models with large inputs keep small-object detail;
+  the default ~640x480 behavior is unchanged (#529).
+- **Feature**: iOS results now carry the same `preMs`/`inferenceMs`/`postMs` per-stage timing as Android, in both
+  single-image predictions and camera streams (requires the UltralyticsYOLO 8.9.5 pod).
+- **Bug Fix**: iOS single-image `speed` is now reported in milliseconds — it was seconds, a 1000x discrepancy
+  against Android.
+- **Enhancement**: Replace deprecated window system-bar color setters with `SystemBarStyle`, resolving the Play
+  Console Android 15 edge-to-edge warning.
+
 ## 0.6.3
 
 - **Feature**: Qualcomm NPU support on Android — official `*_qnn.onnx` context-binary models (now published per HTP

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlatformView.kt
@@ -152,7 +152,9 @@ class YOLOPlatformView(
                 maxFPS = (streamingConfigParam["maxFPS"] as? Number)?.toInt(),
                 throttleIntervalMs = (streamingConfigParam["throttleIntervalMs"] as? Number)?.toInt(),
                 inferenceFrequency = (streamingConfigParam["inferenceFrequency"] as? Number)?.toInt(),
-                skipFrames = (streamingConfigParam["skipFrames"] as? Number)?.toInt()
+                skipFrames = (streamingConfigParam["skipFrames"] as? Number)?.toInt(),
+                analysisWidth = (streamingConfigParam["analysisWidth"] as? Number)?.toInt(),
+                analysisHeight = (streamingConfigParam["analysisHeight"] as? Number)?.toInt()
             )
         } else {
             // Create default config when no streaming config is provided
@@ -424,7 +426,9 @@ class YOLOPlatformView(
                             maxFPS = (configMap["maxFPS"] as? Number)?.toInt(),
                             throttleIntervalMs = (configMap["throttleIntervalMs"] as? Number)?.toInt(),
                             inferenceFrequency = (configMap["inferenceFrequency"] as? Number)?.toInt(),
-                            skipFrames = (configMap["skipFrames"] as? Number)?.toInt()
+                            skipFrames = (configMap["skipFrames"] as? Number)?.toInt(),
+                            analysisWidth = (configMap["analysisWidth"] as? Number)?.toInt(),
+                            analysisHeight = (configMap["analysisHeight"] as? Number)?.toInt()
                         )
                         yoloView.setStreamConfig(streamConfig)
                         result.success(null)

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOStreamConfig.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOStreamConfig.kt
@@ -27,7 +27,12 @@ data class YOLOStreamConfig(
     
     // Inference frequency controls
     val inferenceFrequency: Int? = null,  // Target inference frequency in FPS (e.g., 5, 10, 15, 30)
-    val skipFrames: Int? = null           // Skip frames between inferences (alternative to inferenceFrequency)
+    val skipFrames: Int? = null,          // Skip frames between inferences (alternative to inferenceFrequency)
+
+    // Requested CameraX analysis resolution; null keeps the CameraX default (~640x480). The camera
+    // falls back to the nearest supported size, so any request is safe on any device.
+    val analysisWidth: Int? = null,
+    val analysisHeight: Int? = null
     
     // Note: annotatedImage is intentionally excluded for YOLOView
     // YOLOView uses Canvas drawing (real-time overlay), not bitmap generation

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -793,7 +793,7 @@ class YOLOView @JvmOverloads constructor(
                         .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
                     val analysisWidth = streamConfig?.analysisWidth
                     val analysisHeight = streamConfig?.analysisHeight
-                    if (analysisWidth != null && analysisHeight != null) {
+                    if (analysisWidth != null && analysisHeight != null && analysisWidth > 0 && analysisHeight > 0) {
                         // Opt-in higher analysis resolution: by default CameraX delivers ~640x480 frames, which caps
                         // the detail reaching models with larger inputs. CameraX picks the nearest supported size.
                         analysisBuilder.setResolutionSelector(
@@ -807,6 +807,9 @@ class YOLOView @JvmOverloads constructor(
                                 .build()
                         )
                     } else {
+                        if (analysisWidth != null || analysisHeight != null) {
+                            Log.w(TAG, "Ignoring invalid analysisResolution ${analysisWidth}x${analysisHeight}")
+                        }
                         analysisBuilder.setTargetAspectRatio(AspectRatio.RATIO_4_3)
                     }
                     imageAnalysisUseCase = analysisBuilder.build()

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -18,6 +18,8 @@ import android.os.Build
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.*
 import androidx.camera.core.Camera
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import android.util.SizeF
@@ -179,8 +181,13 @@ class YOLOView @JvmOverloads constructor(
     
     /** Set streaming configuration */
     fun setStreamConfig(config: YOLOStreamConfig?) {
+        val resolutionChanged = config?.analysisWidth != streamConfig?.analysisWidth ||
+            config?.analysisHeight != streamConfig?.analysisHeight
         this.streamConfig = config
         setupThrottlingFromConfig()
+        if (resolutionChanged && camera != null) {
+            startCamera() // rebind so the new analysis resolution takes effect
+        }
     }
 
     /** Set streaming callback */
@@ -778,14 +785,31 @@ class YOLOView @JvmOverloads constructor(
                         .setTargetRotation(targetRotation)
                         .build()
 
-                    imageAnalysisUseCase = ImageAnalysis.Builder()
+                    val analysisBuilder = ImageAnalysis.Builder()
                         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                        .setTargetAspectRatio(AspectRatio.RATIO_4_3)
                         .setTargetRotation(targetRotation)
                         // Ask CameraX for RGBA frames so toBitmap() is a direct buffer copy. The default YUV_420_888
                         // forced a per-frame JPEG encode@100 + decode round-trip (~100ms/frame, ~5 FPS).
                         .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
-                        .build()
+                    val analysisWidth = streamConfig?.analysisWidth
+                    val analysisHeight = streamConfig?.analysisHeight
+                    if (analysisWidth != null && analysisHeight != null) {
+                        // Opt-in higher analysis resolution: by default CameraX delivers ~640x480 frames, which caps
+                        // the detail reaching models with larger inputs. CameraX picks the nearest supported size.
+                        analysisBuilder.setResolutionSelector(
+                            ResolutionSelector.Builder()
+                                .setResolutionStrategy(
+                                    ResolutionStrategy(
+                                        android.util.Size(analysisWidth, analysisHeight),
+                                        ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
+                                    )
+                                )
+                                .build()
+                        )
+                    } else {
+                        analysisBuilder.setTargetAspectRatio(AspectRatio.RATIO_4_3)
+                    }
+                    imageAnalysisUseCase = analysisBuilder.build()
 
                     cameraExecutor = Executors.newSingleThreadExecutor()
                     val myGeneration = cameraGeneration.incrementAndGet()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,8 +13,8 @@ PODS:
     - FlutterMacOS
   - ultralytics_yolo (0.6.0):
     - Flutter
-    - UltralyticsYOLO (< 9.0, >= 8.9.4)
-  - UltralyticsYOLO (8.9.4)
+    - UltralyticsYOLO (< 9.0, >= 8.9.5)
+  - UltralyticsYOLO (8.9.5)
   - url_launcher_ios (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
@@ -62,8 +62,8 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  ultralytics_yolo: b19941dc12a47245d2db81462d4734ac1273e2c8
-  UltralyticsYOLO: 163cd55ce4e0282ebc0d5712dd098d1897d04d7d
+  ultralytics_yolo: 3bab5f36454be0b835aaef0b4445126088e0bdcf
+  UltralyticsYOLO: 2efe21f551e8fdd5c46716bc3461b5aded4a76af
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.3+9
+version: 0.6.4+10
 
 environment:
   sdk: ^3.8.1

--- a/ios/Classes/YOLOInstanceManager.swift
+++ b/ios/Classes/YOLOInstanceManager.swift
@@ -473,8 +473,11 @@ class YOLOInstanceManager {
       }
     }
 
-    // Include speed metric
-    resultDict["speed"] = result.speed
+    // Include timing: total speed plus the pre/inference/post breakdown (milliseconds)
+    resultDict["speed"] = result.speed * 1000  // align with Android: milliseconds
+    resultDict["preMs"] = result.preMs
+    resultDict["inferenceMs"] = result.inferenceMs
+    resultDict["postMs"] = result.postMs
 
     return resultDict
   }

--- a/ios/Classes/YOLOView.swift
+++ b/ios/Classes/YOLOView.swift
@@ -2079,6 +2079,9 @@ extension YOLOView {
     // Add performance metrics (if enabled)
     if config.includeProcessingTimeMs {
       map["processingTimeMs"] = result.speed * 1000
+      map["preMs"] = result.preMs
+      map["inferenceMs"] = result.inferenceMs
+      map["postMs"] = result.postMs
     }
 
     if config.includeFps {

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -17,7 +17,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # `no rule to process file ... net.daringfireball.markdown` warning on every Xcode build.
   s.source_files = 'Classes/**/*.{swift,h,m}'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.4', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.5', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/widgets/yolo_controller.dart
+++ b/lib/widgets/yolo_controller.dart
@@ -223,6 +223,8 @@ class YOLOViewController {
         'throttleIntervalMs': config.throttleInterval?.inMilliseconds,
         'inferenceFrequency': config.inferenceFrequency,
         'skipFrames': config.skipFrames,
+        'analysisWidth': config.analysisResolution?.width.round(),
+        'analysisHeight': config.analysisResolution?.height.round(),
       });
 
   Future<void> stop() => _invoke('stop');

--- a/lib/yolo_streaming_config.dart
+++ b/lib/yolo_streaming_config.dart
@@ -1,5 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import 'dart:ui' show Size;
+
 /// Configuration class for customizing YOLO streaming behavior.
 ///
 /// This class allows fine-grained control over what data is included in
@@ -112,6 +114,21 @@ class YOLOStreamingConfig {
   /// `skipFrames` takes precedence.
   final int? skipFrames;
 
+  /// Requested camera analysis resolution (Android only).
+  ///
+  /// By default CameraX delivers analysis frames at its default size
+  /// (typically 640x480), which caps the detail available to models with
+  /// larger inputs - small objects can be lost to the upscale. Set this to
+  /// request a higher analysis resolution, e.g. `Size(1280, 960)` for an
+  /// 800px model. The camera falls back to the nearest supported size, and
+  /// detection coordinates are normalized so overlays are unaffected.
+  ///
+  /// Higher resolutions increase the per-frame copy and downscale cost, so
+  /// leave this null (the default) unless small-object detail matters more
+  /// than peak FPS. iOS analysis frames already track the capture session
+  /// resolution and ignore this setting.
+  final Size? analysisResolution;
+
   /// Creates a YOLOStreamingConfig with custom settings.
   ///
   /// This constructor allows full customization of streaming behavior.
@@ -129,6 +146,7 @@ class YOLOStreamingConfig {
     this.throttleInterval,
     this.inferenceFrequency,
     this.skipFrames,
+    this.analysisResolution,
   });
 
   /// Creates a minimal configuration optimized for maximum performance.
@@ -155,7 +173,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a custom configuration with specified parameters.
   ///
@@ -182,6 +201,7 @@ class YOLOStreamingConfig {
     this.throttleInterval,
     this.inferenceFrequency,
     this.skipFrames,
+    this.analysisResolution,
   }) : includeDetections = includeDetections ?? true,
        includeClassifications = includeClassifications ?? true,
        includeProcessingTimeMs = includeProcessingTimeMs ?? true,
@@ -209,7 +229,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a configuration with pose keypoints.
   ///
@@ -229,7 +250,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a full configuration with all data included.
   ///
@@ -255,7 +277,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a debug configuration with all data and images.
   ///
@@ -278,7 +301,8 @@ class YOLOStreamingConfig {
       maxFPS = null,
       throttleInterval = null,
       inferenceFrequency = null,
-      skipFrames = null;
+      skipFrames = null,
+      analysisResolution = null;
 
   /// Creates a throttled configuration with specified FPS limit.
   ///
@@ -387,6 +411,7 @@ class YOLOStreamingConfig {
         'maxFPS: $maxFPS, '
         'throttleInterval: ${throttleInterval?.inMilliseconds}ms, '
         'inferenceFrequency: $inferenceFrequency, '
-        'skipFrames: $skipFrames)';
+        'skipFrames: $skipFrames, '
+        'analysisResolution: $analysisResolution)';
   }
 }

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -489,6 +489,11 @@ class _YOLOViewState extends State<YOLOView> {
       if (widget.streamingConfig!.skipFrames != null) {
         streamConfig['skipFrames'] = widget.streamingConfig!.skipFrames;
       }
+      final analysisResolution = widget.streamingConfig!.analysisResolution;
+      if (analysisResolution != null) {
+        streamConfig['analysisWidth'] = analysisResolution.width.round();
+        streamConfig['analysisHeight'] = analysisResolution.height.round();
+      }
 
       creationParams['streamingConfig'] = streamConfig;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.3
+version: 0.6.4
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues

--- a/test/yolo_view_test.dart
+++ b/test/yolo_view_test.dart
@@ -342,6 +342,7 @@ void main() {
                 throttleInterval: Duration(milliseconds: 120),
                 inferenceFrequency: 3,
                 skipFrames: 2,
+                analysisResolution: Size(1280, 960),
               ),
               onResult: results.addAll,
               onPerformanceMetrics: metrics.add,
@@ -376,6 +377,8 @@ void main() {
           'throttleIntervalMs': 120,
           'inferenceFrequency': 3,
           'skipFrames': 2,
+          'analysisWidth': 1280,
+          'analysisHeight': 960,
         });
         expect(loadedModels, ['camera_model.tflite']);
 


### PR DESCRIPTION
Combines #531 and #532 with the 0.6.4 release bump:

- **Opt-in camera analysis resolution on Android** (#529): `YOLOStreamingConfig.analysisResolution` requests a higher CameraX analysis size through a `ResolutionSelector` with closest-size fallback; non-positive values are ignored with a warning; runtime config changes rebind the camera. Default ~640x480 behavior unchanged.
- **iOS per-stage timing bridge**: `preMs`/`inferenceMs`/`postMs` flow from the published UltralyticsYOLO 8.9.5 pod into single-image and stream results, matching Android keys, and single-image `speed` is fixed from seconds to milliseconds (a 1000x cross-platform discrepancy). Podspec floor raised to `>= 8.9.5`.
- **0.6.4 version bump + changelog**, ready to tag for pub.dev on merge.

Verified: `flutter analyze` clean, all Dart tests pass, plugin Kotlin compiles, example iOS app builds against the published pod with no local overrides.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR releases `0.6.4` with better camera-stream quality on Android 📷, more consistent performance timing on iOS ⏱️, and an Android system UI update for newer platform requirements ✅.

### 📊 Key Changes
- Added an **optional `analysisResolution` setting for Android camera streams** 🖼️  
  - Developers can now request a higher CameraX analysis resolution through `YOLOStreamingConfig.analysisResolution`.
  - If the exact size is not supported, Android automatically falls back to the closest available resolution.
  - Default behavior stays the same, so existing apps keep using the current lower-resolution flow unless they opt in.

- Updated the Android camera pipeline to **rebind the camera when analysis resolution changes** 🔄  
  - This ensures new resolution settings take effect immediately during streaming.

- Improved **iOS timing metrics** to match Android 📈  
  - iOS results now include `preMs`, `inferenceMs`, and `postMs` for both single-image prediction and live camera streaming.
  - This required updating the iOS `UltralyticsYOLO` pod dependency to `8.9.5`.

- Fixed an **iOS speed unit bug** 🐛  
  - The `speed` value for single-image inference is now reported in milliseconds instead of seconds.
  - This removes a major mismatch between iOS and Android reporting.

- Replaced deprecated Android system bar color APIs with **`SystemBarStyle`** 🎨  
  - This resolves the Android 15 / Play Console edge-to-edge warning.

- Bumped package version from **`0.6.3` to `0.6.4`** 🚀

### 🎯 Purpose & Impact
- **Better small-object detection on Android** 🔍  
  - Higher analysis resolution can preserve more image detail for larger-input YOLO models, which may improve results for distant or tiny objects.

- **No disruption for current users** 👍  
  - Since the higher resolution setting is opt-in, existing apps keep the same performance and behavior by default.

- **More accurate and comparable performance reporting across platforms** 📊  
  - With matching timing breakdowns on iOS and Android, developers can debug, benchmark, and optimize apps more easily.

- **Fixes misleading iOS timing data** ⏱️  
  - Correct millisecond reporting prevents confusion and makes app metrics more trustworthy.

- **Better Android compatibility going forward** 🛡️  
  - The system UI update helps apps stay aligned with newer Android requirements and avoids Play Console warnings.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `example/ios/Podfile.lock`
</details>
