### PR TITLE
Update example to UltralyticsYOLO 8.9.7

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
   - ultralytics_yolo (0.6.0):
     - Flutter
     - UltralyticsYOLO (< 9.0, >= 8.9.5)
-  - UltralyticsYOLO (8.9.5)
+  - UltralyticsYOLO (8.9.7)
   - url_launcher_ios (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
@@ -63,7 +63,7 @@ SPEC CHECKSUMS:
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   ultralytics_yolo: 3bab5f36454be0b835aaef0b4445126088e0bdcf
-  UltralyticsYOLO: 2efe21f551e8fdd5c46716bc3461b5aded4a76af
+  UltralyticsYOLO: c0ccbac7cfe65b41f5012f8fe81a4e21cc0d63d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 


### PR DESCRIPTION
Lockfile refresh pulling ultralytics/yolo-ios-app#278 into the example app: the vDSP/vImage semantic postprocess and the pod-level `SWIFT_OPTIMIZATION_LEVEL=-O`, so debug builds of the example show shipping-grade timings. No plugin code changes — the bridge forwards the class map untyped and Android has no debug-optimization cliff.

Verified: example builds for the iOS simulator against the published 8.9.7 pod.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR appears to include project dependency or build environment updates, but the main code changes are not visible in the provided diff. 🔧📦

### 📊 Key Changes
- `example/ios/Podfile.lock` was updated, indicating changes to iOS example app dependencies or CocoaPods resolution.
- No source-code diff was included in the provided PR details, so no app logic, UI, or feature changes can be confirmed from the available information.
- The update likely reflects a dependency sync, environment refresh, or compatibility adjustment for the Flutter example app on iOS. 🍎

### 🎯 Purpose & Impact
- Helps keep the iOS example app dependencies aligned and reproducible across developer environments. ✅
- May improve build stability or compatibility for users running the example app on iOS devices or simulators.
- Since no functional code changes are shown, the expected impact is likely low-risk and mostly related to development/setup rather than end-user features. 🚀
- If more diff details are shared, a more precise summary of functional changes can be provided.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `example/ios/Podfile.lock`
</details>
