### PR TITLE
Add CocoaPods badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml)
 [![.github/workflows/ci.yml](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/ultralytics/yolo-flutter-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-flutter-app)
+[![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,7 @@
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/format.yml)
 [![.github/workflows/ci.yml](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-flutter-app/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/ultralytics/yolo-flutter-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-flutter-app)
+[![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- add the UltralyticsYOLO CocoaPods badge to the English README
- mirror the same badge in the Chinese README

## Validation
- rg -n "CocoaPods" README.md README.zh-CN.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧩 This PR updates the English and Chinese READMEs to add a CocoaPods version badge for the `UltralyticsYOLO` iOS package.

### 📊 Key Changes
- Added a new **CocoaPods badge** to `README.md`.
- Added the same **CocoaPods badge** to `README.zh-CN.md`.
- The badge links directly to the **[UltralyticsYOLO CocoaPods page](https://cocoapods.org/pods/UltralyticsYOLO)** for quick access to package version details.

### 🎯 Purpose & Impact
- Improves project visibility for **iOS developers** by clearly showing that the library is available via CocoaPods 📱
- Makes it easier for users to **find the latest published pod version** at a glance 👀
- Keeps the English and Chinese documentation **consistent and up to date** 🌍
- This is a **documentation-only change**, so it does not affect app behavior, performance, or functionality ✅