### PR TITLE
Fix Android CI emulator disk usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,6 @@ jobs:
         working-directory: example
         run: flutter build apk --debug
 
-      - name: Build example Android release bundle
-        working-directory: example
-        run: flutter build appbundle --release
-
-      - name: Verify example Android release bundle
-        run: scripts/build_play_store_assets.sh --verify-aab example/build/app/outputs/bundle/release/app-release.aab
-
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -100,7 +93,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
-          target: google_apis
+          target: default
           working-directory: example
           script: |
             set -eux
@@ -110,6 +103,13 @@ jobs:
             sleep 10
             adb shell pidof com.ultralytics.yolo
             adb shell dumpsys activity activities | grep com.ultralytics.yolo
+
+      - name: Build example Android release bundle
+        working-directory: example
+        run: flutter build appbundle --release
+
+      - name: Verify example Android release bundle
+        run: scripts/build_play_store_assets.sh --verify-aab example/build/app/outputs/bundle/release/app-release.aab
 
   example-ios:
     runs-on: macos-26


### PR DESCRIPTION
## Summary
- run the Android emulator smoke test before release AAB generation to keep disk usage lower during SDK image install
- use the smaller default Android emulator system image because the smoke test does not need Google APIs

## Validation
- actionlint .github/workflows/ci.yml
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"
- git diff --check

Fixes failing main CI run: https://github.com/ultralytics/yolo-flutter-app/actions/runs/27365346456/job/80863253216

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR reorganizes the Android CI workflow to improve emulator reliability while still preserving release bundle build and verification steps.

### 📊 Key Changes
- Moved the **Android release app bundle build** and **AAB verification** steps to run **after** the emulator-based test step in `.github/workflows/ci.yml`.
- Changed the Android emulator setup target from `google_apis` to `default`.
- Kept existing checks for:
  - building the example Android debug APK
  - launching the example app on an emulator
  - validating the Play Store release bundle with `build_play_store_assets.sh`

### 🎯 Purpose & Impact
- 🚀 **Improves CI stability** by simplifying the emulator configuration, which can reduce setup issues in GitHub Actions.
- 🧪 **Prioritizes runtime testing first**, ensuring the example app actually launches successfully before spending time building release artifacts.
- 📦 **Maintains release quality checks** by still building and verifying the Android App Bundle for Play Store readiness.
- ⏱️ **Potentially makes failures easier to diagnose**, since emulator/test issues will appear earlier in the workflow.