### PR TITLE
Make Snapdragon QNN runtime opt-in in the example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ final yolo = YOLO(
 );
 ```
 
-Without the Gradle opt-in, loading a `_qnn.onnx` model fails with a clear error and TFLite models are unaffected.
+Without the Gradle opt-in, loading a `_qnn.onnx` model fails with a clear error and TFLite models are unaffected. The bundled example app follows the same opt-in — it ships without the QNN runtime to keep its download small, so build it with `ENABLE_QNN=1` (e.g. `ENABLE_QNN=1 flutter run --release`) to test the NPU path on a device.
 See the [performance guide](doc/performance.md) for measured CPU/GPU/NPU numbers and tuning notes.
 
 ## 🧭 Official vs. Custom

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,7 @@ final yolo = YOLO(
 );
 ```
 
-未添加上述 Gradle 配置时，加载 `_qnn.onnx` 模型会返回明确的错误信息，TFLite 模型不受影响。CPU/GPU/NPU 实测数据与调优说明见[性能指南](doc/performance.md)。
+未添加上述 Gradle 配置时，加载 `_qnn.onnx` 模型会返回明确的错误信息，TFLite 模型不受影响。随附的示例应用同样采用此可选启用方式——默认不包含 QNN 运行时以保持较小的下载体积，如需在设备上测试 NPU 路径，请使用 `ENABLE_QNN=1` 构建（例如 `ENABLE_QNN=1 flutter run --release`）。CPU/GPU/NPU 实测数据与调优说明见[性能指南](doc/performance.md)。
 
 ## 🧭 官方模型还是自定义模型
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -48,7 +48,7 @@ with the preprocess / inference / postprocess split beneath it.
 
 - **Speed** values are the full `predict()` time — preprocessing + inference + postprocessing, excluding annotation
   drawing — as the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg).
-  <br>Reproduce with `flutter test integration_test/qnn_benchmark_test.dart -d <device> --dart-define=RUN_BENCH=true`
+  <br>Reproduce with `ENABLE_QNN=1 flutter test integration_test/qnn_benchmark_test.dart -d <device> --dart-define=RUN_BENCH=true` (the example app's QNN runtime is opt-in)
 - **CPU** and **GPU** run the default official INT8 TFLite assets the plugin auto-downloads, on LiteRT with
   `useGpu: false` / `true`. **NPU** runs the `*_v81_qnn.onnx` context binaries (INT8 weights, 16-bit activations) from
   the same release via the ONNX Runtime QNN Execution Provider.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,6 +15,11 @@ def hasReleaseSigning = keystoreProperties["storeFile"] &&
     (keystoreProperties["keyPassword"] ?: System.getenv("ANDROID_KEY_PASSWORD")) &&
     (keystoreProperties["storePassword"] ?: System.getenv("ANDROID_STORE_PASSWORD"))
 
+// Snapdragon NPU (QNN) runtime is optional and OFF by default — it adds ~230 MB of uncompressed arm64 native libs.
+// Opt in for on-device NPU testing with the ENABLE_QNN env var (reliable through the `flutter` CLI) or a -Pqnn
+// Gradle property, e.g.:  ENABLE_QNN=1 flutter build appbundle --release
+def qnnEnabled = project.hasProperty("qnn") || (System.getenv("ENABLE_QNN") in ["1", "true", "TRUE", "yes"])
+
 android {
     namespace = "com.ultralytics.yolo"
     compileSdk = flutter.compileSdkVersion
@@ -55,11 +60,12 @@ android {
         checkReleaseBuilds false
     }
 
-    // The Hexagon DSP loads QNN Skel libraries via filesystem paths (ADSP_LIBRARY_PATH), so they must exist as
-    // real files in nativeLibraryDir rather than being mmapped out of the APK.
+    // When QNN is enabled the Hexagon DSP loads its Skel libraries via filesystem paths (ADSP_LIBRARY_PATH), so they
+    // must be real files in nativeLibraryDir rather than mmapped out of the APK. Only needed for the QNN runtime, so
+    // it is off by default — the standard release then packs native libs compressed.
     packagingOptions {
         jniLibs {
-            useLegacyPackaging = true
+            useLegacyPackaging = qnnEnabled
         }
     }
 }
@@ -69,12 +75,16 @@ flutter {
 }
 
 dependencies {
-    // Snapdragon NPU support for QNN context-binary ONNX models (*_qnn.onnx). The plugin declares this compileOnly;
-    // apps opt in to the ~70MB arm64 runtime by adding it here.
-    implementation("com.microsoft.onnxruntime:onnxruntime-android-qnn:1.26.0")
-    // Override the AAR's transitive QAIRT 2.42 with 2.46: 2.42's device table predates the
-    // Snapdragon 8 Elite Gen 5 (SM8850), failing QnnDevice_create with INVALID_CONFIG.
-    implementation("com.qualcomm.qti:qnn-runtime:2.46.0")
+    // Snapdragon NPU support for QNN context-binary ONNX models (*_qnn.onnx). The plugin declares this compileOnly,
+    // and the runtime adds ~230 MB of uncompressed arm64 native libs, so it is OFF BY DEFAULT to keep the release
+    // AAB lean — QNN acceleration is optional. Opt in (see `qnnEnabled` above) for on-device NPU testing, e.g.:
+    //   ENABLE_QNN=1 flutter build appbundle --release
+    if (qnnEnabled) {
+        implementation("com.microsoft.onnxruntime:onnxruntime-android-qnn:1.26.0")
+        // Override the AAR's transitive QAIRT 2.42 with 2.46: 2.42's device table predates the
+        // Snapdragon 8 Elite Gen 5 (SM8850), failing QnnDevice_create with INVALID_CONFIG.
+        implementation("com.qualcomm.qti:qnn-runtime:2.46.0")
+    }
 }
 
 // Bundle the nano YOLO models into the app at build time. They are NOT committed to git (large binaries, gitignored);

--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -7,8 +7,8 @@
 // using the native speed (pre + inference + post, no plotting). CPU and GPU rows use the default
 // official int8 TFLite assets (what the app ships); QNN rows use the release context binaries.
 //
-// Run with:
-//   flutter test integration_test/qnn_benchmark_test.dart -d <device> [--dart-define=RUN_BENCH=1]
+// Run with (the QNN runtime is opt-in, off by default):
+//   ENABLE_QNN=1 flutter test integration_test/qnn_benchmark_test.dart -d <device> [--dart-define=RUN_BENCH=1]
 
 import 'dart:io';
 import 'dart:typed_data';

--- a/example/integration_test/qnn_smoke_test.dart
+++ b/example/integration_test/qnn_smoke_test.dart
@@ -6,7 +6,8 @@
 // through the ONNX Runtime QNN Execution Provider (Hexagon NPU), and verifies
 // real detections on bus.jpg.
 //
-// Run with:  flutter test integration_test/qnn_smoke_test.dart -d <device>
+// Run with (the QNN runtime is opt-in, off by default):
+//   ENABLE_QNN=1 flutter test integration_test/qnn_smoke_test.dart -d <device>
 
 import 'dart:io';
 import 'dart:typed_data';


### PR DESCRIPTION
## Summary

The bundled example app force-included the Qualcomm QNN + ONNX Runtime native libraries (`implementation(...)`), adding **~230 MB of uncompressed arm64 code** (`libQnnHtpPrepare.so` alone is 90 MB) and roughly **doubling the release AAB to ~163 MB**. QNN/NPU acceleration is optional — the plugin keeps it `compileOnly` for pub.dev consumers — so the bundled example should not ship it by default.

## Change

Gate the QNN runtime (and the QNN-only `useLegacyPackaging`) behind a default-off flag in `example/android/app/build.gradle`. Opt in for on-device NPU testing with `ENABLE_QNN=1` (env var — reliable through the `flutter` CLI) or `-Pqnn`:

```bash
ENABLE_QNN=1 flutter build appbundle --release
```

## Result

| | before | after (default) |
|---|---|---|
| Release AAB | 162.9 MB | **87.2 MB** |
| arm64 native `.so` | 250 MB | ~24 MB |
| QNN / ONNX-Runtime libs | ~230 MB | none |

Core CPU/GPU inference (LiteRT) is unchanged. With `ENABLE_QNN=1` the full NPU stack returns.

## Docs

README + `README.zh-CN` NPU sections, the performance guide, the `qnn_*` integration-test run commands, and the agent guide now document the opt-in.

No plugin version bump — this is an example-app build-config change; the published plugin (which already keeps QNN `compileOnly`) is unaffected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes Snapdragon QNN/NPU support in the Flutter example app **optional by default** 📦, reducing app size while clearly documenting how to enable it for on-device NPU testing ⚡.

### 📊 Key Changes
- Added an **opt-in build flag** for QNN support in the example Android app using `ENABLE_QNN=1` or Gradle `-Pqnn` 🛠️
- Changed the example app so it **does not bundle the QNN runtime by default**, keeping the default download/build much smaller 📉
- Updated Android `build.gradle` so QNN-related dependencies are only included **when explicitly enabled** 🔌
- Made `useLegacyPackaging` conditional, enabling it **only for QNN builds**, since the QNN runtime requires native libraries as real files 📦
- Expanded README docs in **English and Chinese** to explain the new opt-in behavior and how to test the NPU path 🌍
- Updated performance and integration test instructions to show that QNN benchmarks and smoke tests must be run with `ENABLE_QNN=1` ✅

### 🎯 Purpose & Impact
- Keeps the example app **lighter and easier to distribute** for most users, since large QNN native libraries are excluded by default 🚀
- Makes QNN/NPU acceleration a **deliberate advanced option** for users who need Snapdragon device testing, rather than forcing extra size on everyone 🎛️
- Reduces confusion by documenting exactly **why QNN models may fail to load** without the opt-in enabled, while confirming that TFLite models are unaffected 🧩
- Improves the developer experience with **clearer setup and test commands** for benchmarking and validating NPU inference on supported devices 📱
- Helps maintain compatibility with newer Snapdragon hardware by keeping the QNN runtime override in the conditional dependency setup 🔧