### PR TITLE
Bump example app build number to 0.6.5+12

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.5+11
+version: 0.6.5+12
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Play Console reported `versionCode 11` already used, rejecting the 0.6.5 upload. Bump the example app's Android `versionCode` (the `+N` in `example/pubspec.yaml`) to **12** so the upload is accepted.

Plugin version (`0.6.5`) is unchanged — this is example-app-only, no pub.dev republish. Regenerated AAB: `ultralytics-yolo-0.6.5-build12.aab` (still the lean 87.2 MB, no QNN).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔖 This PR makes a small example app release update by incrementing the `ultralytics_yolo_example` version from `0.6.5+11` to `0.6.5+12`.

### 📊 Key Changes
- Updated the example app version in `example/pubspec.yaml`
- Changed build/version number from `0.6.5+11` to `0.6.5+12`
- No code, feature, dependency, or configuration logic changes were included

### 🎯 Purpose & Impact
- Helps keep the example app’s package metadata aligned with the latest internal build/release state 📦
- Useful for distinguishing this example app build from previous ones during testing or distribution 🔍
- Minimal user impact: this is an administrative version bump, not a functional update ✅