### PR TITLE
Use quantize export arg in TFLite export examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Android inference runs on [LiteRT](https://developers.google.com/edge/litert) 2.
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 ## 🎯 Choosing an API

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,7 +221,7 @@ Android 推理运行在 [LiteRT](https://developers.google.com/edge/litert) 2.x 
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 ## 🎯 该用哪个 API

--- a/doc/install.md
+++ b/doc/install.md
@@ -185,7 +185,7 @@ iOS inference runs on Core ML, which automatically uses the Neural Engine and GP
 Android inference runs on LiteRT 2.x via `CompiledModel`, which automatically tries a GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. Confirm actual delegate placement from device logs. fp16, non-end-to-end exports are still useful for GPU benchmarking:
 
 ```python
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 Keep `useGpu: true` for the automatic LiteRT GPU -> CPU ladder. See the [Performance Guide](performance.md) for the current device results.

--- a/doc/models.md
+++ b/doc/models.md
@@ -59,7 +59,7 @@ Official export properties:
 | Model IDs      | `yolo26{n,s,m,l,x}`                               | `yolo26{n,s,m,l,x}`                 |
 | Tasks          | detect, seg, sem, cls, pose, obb                  | detect, seg, sem, cls, pose, obb    |
 | Format         | `.tflite`                                         | `.mlpackage.zip`                    |
-| Quantization   | int8 dynamic range TFLite from `int8=True` export | int8 Core ML                        |
+| Quantization   | int8 dynamic range TFLite from `quantize=8` export | int8 Core ML                        |
 | `imgsz`        | `224` cls; `640` others                           | `224` cls; `1024` OBB; `640` others |
 | `nms`          | `False`                                           | `False`                             |
 | `end2end`      | `False`                                           | `True`                              |
@@ -209,7 +209,7 @@ Android inference runs on LiteRT 2.x with an automatic GPU -> CPU accelerator la
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 ## 🔄 Switching Models

--- a/doc/models.md
+++ b/doc/models.md
@@ -54,17 +54,17 @@ The Flutter resolver uses the TFLite release for Android and the Core ML release
 
 Official export properties:
 
-| Property       | TFLite                                            | Core ML                             |
-| -------------- | ------------------------------------------------- | ----------------------------------- |
-| Model IDs      | `yolo26{n,s,m,l,x}`                               | `yolo26{n,s,m,l,x}`                 |
-| Tasks          | detect, seg, sem, cls, pose, obb                  | detect, seg, sem, cls, pose, obb    |
-| Format         | `.tflite`                                         | `.mlpackage.zip`                    |
+| Property       | TFLite                                             | Core ML                             |
+| -------------- | -------------------------------------------------- | ----------------------------------- |
+| Model IDs      | `yolo26{n,s,m,l,x}`                                | `yolo26{n,s,m,l,x}`                 |
+| Tasks          | detect, seg, sem, cls, pose, obb                   | detect, seg, sem, cls, pose, obb    |
+| Format         | `.tflite`                                          | `.mlpackage.zip`                    |
 | Quantization   | int8 dynamic range TFLite from `quantize=8` export | int8 Core ML                        |
-| `imgsz`        | `224` cls; `640` others                           | `224` cls; `1024` OBB; `640` others |
-| `nms`          | `False`                                           | `False`                             |
-| `end2end`      | `False`                                           | `True`                              |
-| Calibration    | `ultralytics.cfg.TASK2CALIBRATIONDATA` per task   | exporter default                    |
-| Postprocessing | Android native                                    | Swift/Core ML                       |
+| `imgsz`        | `224` cls; `640` others                            | `224` cls; `1024` OBB; `640` others |
+| `nms`          | `False`                                            | `False`                             |
+| `end2end`      | `False`                                            | `True`                              |
+| Calibration    | `ultralytics.cfg.TASK2CALIBRATIONDATA` per task    | exporter default                    |
+| Postprocessing | Android native                                     | Swift/Core ML                       |
 
 The TFLite export script passes both `nms=False` and `end2end=False`. `nms=False` excludes an exported NMS operator, while `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path. Core ML assets use `end2end=True`, which is the YOLO26 output contract consumed by the Swift decoders. For Android calibration, the script uses the Ultralytics `TASK2CALIBRATIONDATA` mapping by default: detect `coco128.yaml`, segment `coco128-seg.yaml`, classify `imagenet100`, pose `coco8-pose.yaml`, OBB `dota128.yaml`, and semantic `cityscapes8.yaml`.
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -157,7 +157,7 @@ fp16 non-end-to-end TFLite exports are still useful for GPU benchmarking:
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 Use CPU when:
@@ -223,7 +223,7 @@ This is the canonical record of the on-device profiling behind the Ultralytics Y
 
 - **Device (ground truth):** Samsung Galaxy S26 (`SM S9420`), Android 16 / API 36.
 - **Build:** Flutter example debug APK, package `com.ultralytics.yolo`.
-- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `int8=True`, `nms=False`, `end2end=False`.
+- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `quantize=8`, `nms=False`, `end2end=False`.
 - **Runtime:** Android LiteRT 2.x `CompiledModel` with `useGpu: true`.
 - **UI:** `YOLOShowcase` real-time camera view with the default task/size controls and threshold sliders.
 - **Numbers:** EMA-smoothed app metrics after the camera and model are warm.
@@ -322,7 +322,7 @@ The app UI correctly showed the resolver failure. To validate the camera/inferen
 ### Current Shipped Configuration
 
 - Android official assets: YOLO26 int8 `.tflite`, `n/s/m/l/x`, detect/segment/semantic/classify/pose/OBB, hosted on `ultralytics/yolo-flutter-app` release `v0.3.5`.
-- Android export settings: `int8=True`, `nms=False`, `end2end=False`; classify `imgsz=224`, all other tasks `imgsz=640`; calibration from `ultralytics.cfg.TASK2CALIBRATIONDATA`.
+- Android export settings: `quantize=8`, `nms=False`, `end2end=False`; classify `imgsz=224`, all other tasks `imgsz=640`; calibration from `ultralytics.cfg.TASK2CALIBRATIONDATA`.
 - Android runtime: LiteRT 2.x with GPU -> CPU accelerator fallback.
 - Example UI: controls expose all six tasks and all five model sizes; model changes use one modal loading overlay for downloads and native model reloads.
 - Bundled models: local/release builds fetch the six `yolo26n` nano models into `example/assets/models/` at build time (gitignored, not committed; skipped under CI), so nano tasks work offline with no first-run download; larger sizes download on demand.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -64,7 +64,7 @@ Task and labels are auto-detected from the model's embedded metadata. If your cu
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder; iOS uses Core ML. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. fp16 non-end-to-end exports are useful for GPU benchmarking:
 
 ```python
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 ## ⚡ Step 4: Minimal Detection Code

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -149,7 +149,7 @@ await controller.setThresholds(
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. To compare against fp16, export a non-end-to-end TFLite model:
 
 ```python
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 On a Samsung Galaxy S26, the official `yolo26n_int8.tflite` compiled with the LiteRT OpenCL GPU delegate and ran around 15 FPS / 32 ms in the live camera example. Leave `useGpu: true` (the default), inspect LiteRT logs for `LITERT_CL` or CPU fallback, and benchmark the exact model you plan to ship.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -124,7 +124,7 @@ final yolo = YOLO(
 On Android, inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. For GPU benchmarking, fp16 non-end-to-end exports are also useful:
 
 ```python
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
 Keep `useGpu: true` for automatic GPU -> CPU fallback and verify actual delegate placement on target devices.

--- a/doc/use_gpu_feature.md
+++ b/doc/use_gpu_feature.md
@@ -55,10 +55,10 @@ Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on support
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="tflite", half=True, nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="tflite", quantize=16, nms=False, end2end=False, imgsz=640)
 ```
 
-Here `half=True` produces fp16 weights, `nms=False` leaves NMS to the plugin, and `end2end=False` keeps the YOLO26 raw head for the Android LiteRT conversion path. Keep `useGpu: true` and verify the actual delegate from LiteRT logs.
+Here `quantize=16` produces fp16 weights, `nms=False` leaves NMS to the plugin, and `end2end=False` keeps the YOLO26 raw head for the Android LiteRT conversion path. Keep `useGpu: true` and verify the actual delegate from LiteRT logs.
 
 On a Galaxy S26, the official `yolo26n_int8.tflite` compiled fully with the LiteRT OpenCL GPU delegate (`Replacing 395 out of 395 node(s) with delegate (LITERT_CL)`) and ran around **15 FPS / 32 ms** in the live camera example.
 

--- a/scripts/export-tflite-models.py
+++ b/scripts/export-tflite-models.py
@@ -192,7 +192,7 @@ def export_one(model_id: str, imgsz: int, data: str, output_dir: Path) -> None:
     os.chdir(output_dir)
     YOLO(f"{model_id}.pt").export(
         format="tflite",
-        int8=True,
+        quantize=8,
         data=data,
         nms=False,
         end2end=False,


### PR DESCRIPTION
## Summary

Updates the TFLite export examples and scripts to use the new unified `quantize` export arg instead of the deprecated precision booleans `half`/`int8`, following ultralytics/ultralytics#24918.

Precision mapping applied per occurrence:
- `half=True` → `quantize=16` (FP16) — fp16 GPU-benchmarking export snippets across the READMEs and docs.
- `int8=True` → `quantize=8` (INT8) — `scripts/export-tflite-models.py` and the int8 Android export references in `doc/performance.md` and `doc/models.md`.

`README.zh-CN.md` mirrors `README.md`. The historical `CHANGELOG.md` release note and descriptive prose / model filenames (e.g. `yolo26n_int8.tflite`) are intentionally left unchanged.

## Notes

The old args still work with a deprecation warning, so this is documentation/script polish. It should land after ultralytics/ultralytics#24918 ships the `quantize` arg.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the Flutter app docs and export script to use the newer `quantize` export option for YOLO26 TFLite models, replacing older `half=True` and `int8=True` examples for clearer, more consistent model export guidance.

### 📊 Key Changes
- Replaced TFLite export examples across the README and docs:
  - `half=True` ➜ `quantize=16` for fp16-style exports
  - `int8=True` ➜ `quantize=8` for int8-style exports
- Updated the Android model export script in `scripts/export-tflite-models.py` to use `quantize=8` instead of `int8=True`.
- Revised documentation tables and explanations to reflect the new export parameter names.
- Updated wording in GPU and performance docs so the explanation matches the new API, including notes that `quantize=16` produces fp16 weights.

### 🎯 Purpose & Impact
- Improves ✅ consistency between the codebase, docs, and current Ultralytics export API.
- Reduces confusion 📘 for users following setup or benchmarking guides, especially when exporting YOLO26 models for Android.
- Helps prevent export command errors ⚠️ caused by outdated arguments like `half=True` or `int8=True`.
- Makes maintenance easier 🔧 by standardizing on one quantization interface across examples, scripts, and reference docs.
- For most users, this is a documentation and tooling alignment update rather than a runtime behavior change 🚀.