### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,16 +118,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Extract PR Details
+      - name: Get release title
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
         run: |
-          PR_JSON=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title' | sed 's/"/\\"/g')
-          echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
-          echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.build.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
@@ -135,7 +134,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `ultralytics_yolo ${{ needs.check.outputs.current_tag }}` version bump merged; pub.dev publish runs from the tag workflow 🎉\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S07NKMNECKH> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.build.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
@@ -143,4 +142,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S07NKMNECKH> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -79,4 +79,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* New tag and release `${{ github.event.inputs.tag_name }}` published 🎉\n*Job Status:* ${{ job.status }}\n*Release Notes:* https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag_name }}"
+            text: "<!subteam^S07NKMNECKH> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ github.event.inputs.tag_name }}  <https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag_name }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@platform-team` to cut company-wide notification noise.
- Publish notifications surface the GitHub release title + *Release* link; the now-dead `Extract PR Details` step is replaced by a lean `gh release view` step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Streamlined GitHub Actions Slack notifications for releases and tags by switching from PR-based details to cleaner release-focused messages 🚀

### 📊 Key Changes
- Reworked the `publish.yml` workflow to fetch the **release title** directly from GitHub releases instead of looking up the merged PR title.
- Removed the extra PR lookup logic, including:
  - repository checkout for this step
  - `gh pr list` query
  - parsing PR number and title with `jq`
- Added a new workflow step with output `title`, using the current tag to retrieve the release name.
- Simplified Slack success notifications in `publish.yml` to include:
  - workflow name
  - repository name
  - release title or tag
  - direct links to the **Release** and **Run**
- Simplified Slack failure notifications in `publish.yml` to show a shorter, cleaner error message with the tag and run link.
- Updated `tag.yml` Slack notifications to match the same compact format and point directly to the published release.
- Changed Slack mentions from `<!channel>` to a specific Slack subteam mention `<!subteam^S07NKMNECKH>` for more targeted alerts 👥

### 🎯 Purpose & Impact
- Makes release notifications more relevant by highlighting the actual **release name/tag** rather than the merged PR title 🏷️
- Reduces workflow complexity and removes unnecessary PR discovery steps, which can improve reliability and maintainability ⚙️
- Creates more concise Slack messages that are easier for the team to scan quickly 🔍
- Improves consistency across publish and tag workflows, so release-related alerts follow the same format 📣
- Targets notifications to the right audience instead of broadcasting to an entire channel, helping reduce noise in Slack 🔕