### PR TITLE
Linkify PR numbers in publish Slack notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,7 @@ jobs:
           TAG: ${{ needs.check.outputs.current_tag }}
         run: |
           TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.build.result == 'success' && github.event_name == 'push'


### PR DESCRIPTION
Turns the `#<number>` PR reference inside the GitHub release title into a clickable link to the PR in the **Publish to PyPI** success notification, e.g. `(#24965)` → [`#24965`](pull link).

- One line added to the existing `Get release title` step: `sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g"`.
- No-ops on titles without a `#<number>`; `/pull/N` auto-redirects to `/issues/N` if it ever isn't a PR.
- All Slack `text:` payload lines are unchanged — the link is built at the source where the title is fetched.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR improves release notifications by automatically turning pull request references like `#123` in release titles into clickable GitHub links.

### 📊 Key Changes
- Added a new step in `.github/workflows/publish.yml` to post-process the GitHub release title before sending success notifications.
- Updated the workflow to detect PR references in the title, such as `#123`.
- Replaces those plain PR numbers with formatted links pointing directly to the matching pull request in the `ultralytics/yolo-flutter-app` repository.

### 🎯 Purpose & Impact
- Makes release notifications more useful and easier to navigate 📬
- Helps developers and collaborators quickly jump from a release message to the related PR 🔍
- Improves traceability between releases and code changes without altering the app itself 🛠️
- Low-risk workflow enhancement: only affects notification formatting, not build or runtime behavior ✅