### PR TITLE
Speed up segment decode with cache-friendly class argmax

### DIFF
--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -69,7 +69,7 @@ static float intersection_area(const DetectedObject &a, const DetectedObject &b)
 }
 
 // Non-Maximum Suppression (NMS) implementation (for already sorted proposals)
-static void nms_sorted_bboxes(const std::vector<DetectedObject>& objects, std::vector<int>& picked, float nms_threshold) {
+static void nms_sorted_bboxes(const std::vector<DetectedObject>& objects, std::vector<int>& picked, float nms_threshold, int max_picked) {
     picked.clear();
     int n = objects.size();
     std::vector<float> areas(n);
@@ -88,8 +88,10 @@ static void nms_sorted_bboxes(const std::vector<DetectedObject>& objects, std::v
                 break;
             }
         }
-        if (keep)
+        if (keep) {
             picked.push_back(i);
+            if (max_picked > 0 && (int)picked.size() >= max_picked) break;
+        }
     }
 }
 
@@ -148,7 +150,7 @@ Java_com_ultralytics_yolo_ObjectDetector_postprocess(
 
     // Apply Non-Maximum Suppression (NMS)
     std::vector<int> picked;
-    nms_sorted_bboxes(proposals, picked, iou_threshold);
+    nms_sorted_bboxes(proposals, picked, iou_threshold, num_items_threshold);
 
     int count = std::min((int)picked.size(), (int)num_items_threshold);
     std::vector<DetectedObject> objects(count);

--- a/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
@@ -105,21 +105,32 @@ class Classifier(
         val preEnd = System.nanoTime()
         val scores = rtModel.run(floatInput)[0] // flat FloatArray(numClass)
         val inferEnd = System.nanoTime()
-        val indexedScores = scores.mapIndexed { index, score -> index to score }
-        val sorted = indexedScores.sortedByDescending { it.second }
 
-        // Top1
-        val top1 = sorted.firstOrNull()
-        // Top5
-        val top5 = sorted.take(5)
+        val topCount = minOf(5, scores.size)
+        val topIndices = IntArray(topCount) { -1 }
+        val topScores = FloatArray(topCount) { Float.NEGATIVE_INFINITY }
+        for (index in scores.indices) {
+            val score = scores[index]
+            var insert = 0
+            while (insert < topCount && score <= topScores[insert]) insert++
+            if (insert == topCount) continue
+            var move = topCount - 1
+            while (move > insert) {
+                topScores[move] = topScores[move - 1]
+                topIndices[move] = topIndices[move - 1]
+                move--
+            }
+            topScores[insert] = score
+            topIndices[insert] = index
+        }
 
-        val top1Label = if (top1 != null) labelName(top1.first) else "class 0"
-        val top1Score = top1?.second ?: 0f
-        val top1Index: Int = if (top1 != null) top1.first else 0
+        val top1Index = topIndices.firstOrNull()?.takeIf { it >= 0 } ?: 0
+        val top1Score = topScores.firstOrNull()?.takeIf { top1Index >= 0 } ?: 0f
+        val top1Label = labelName(top1Index)
 
-        val top5Indices = top5.map { it.first }
-        val top5Labels = top5.map { (idx, _) -> labelName(idx) }
-        val top5Scores = top5.map { it.second }
+        val top5Indices = topIndices.filter { it >= 0 }
+        val top5Labels = top5Indices.map { labelName(it) }
+        val top5Scores = topScores.take(top5Indices.size)
 
         val probs = Probs(
             top1Label = top1Label,

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -37,6 +37,9 @@ class Segmenter(
     private var classBestScore = FloatArray(0)
     private var classBestIndex = IntArray(0)
 
+    // Reusable per-pixel accumulator for NCHW mask generation (sized to the proto plane on first use).
+    private var maskAccum = FloatArray(0)
+
     // CompiledModel output indices: detection head (rank-3) and mask proto (rank-4) may be returned in either order.
     private var detOutIndex = 0
     private var maskOutIndex = 1
@@ -359,24 +362,54 @@ class Segmenter(
             }
             // proto flat layout: NHWC -> protoFlat[(y*maskW + x)*maskC + c]; NCHW -> protoFlat[c*planeSize + y*maskW + x].
             val planeSize = maskH * maskW
-            for (y in outputBox.top until outputBox.bottom) {
-                val rowBase = y * maskW
-                for (x in outputBox.left until outputBox.right) {
-                    val pix = rowBase + x
-                    var v = 0f
-                    if (protoNchw) {
-                        for (c in 0 until coeffCount) {
-                            v += det.maskCoeffs[c] * protoFlat[c * planeSize + pix]
+            if (protoNchw) {
+                // Plane-major accumulation for the NCHW proto: stream each coeff's proto plane over the box into a
+                // per-pixel accumulator (cache-friendly), instead of gathering coeffCount planeSize-strided reads per
+                // pixel. The per-pixel add order over c is unchanged, so the accumulated value is identical to the
+                // per-pixel dot product. The accumulator is cleared over this box first; detections are independent.
+                if (maskAccum.size < planeSize) maskAccum = FloatArray(planeSize)
+                val acc = maskAccum
+                for (y in outputBox.top until outputBox.bottom) {
+                    val rowBase = y * maskW
+                    java.util.Arrays.fill(acc, rowBase + outputBox.left, rowBase + outputBox.right, 0f)
+                }
+                for (c in 0 until coeffCount) {
+                    val coeff = det.maskCoeffs[c]
+                    val planeBase = c * planeSize
+                    for (y in outputBox.top until outputBox.bottom) {
+                        val rowBase = y * maskW
+                        val protoRow = planeBase + rowBase
+                        for (x in outputBox.left until outputBox.right) {
+                            acc[rowBase + x] += coeff * protoFlat[protoRow + x]
                         }
-                    } else {
+                    }
+                }
+                for (y in outputBox.top until outputBox.bottom) {
+                    val rowBase = y * maskW
+                    for (x in outputBox.left until outputBox.right) {
+                        val pix = rowBase + x
+                        val v = acc[pix]
+                        if (v > threshold) {
+                            combinedPixels[pix] = color
+                            instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
+                        }
+                    }
+                }
+            } else {
+                // NHWC proto: classes are contiguous per pixel, so the per-pixel dot product already streams cache lines.
+                for (y in outputBox.top until outputBox.bottom) {
+                    val rowBase = y * maskW
+                    for (x in outputBox.left until outputBox.right) {
+                        val pix = rowBase + x
                         val base = pix * maskC
+                        var v = 0f
                         for (c in 0 until coeffCount) {
                             v += det.maskCoeffs[c] * protoFlat[base + c]
                         }
-                    }
-                    if (v > threshold) {
-                        combinedPixels[pix] = color
-                        instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
+                        if (v > threshold) {
+                            combinedPixels[pix] = color
+                            instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
+                        }
                     }
                 }
             }

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -233,8 +233,7 @@ class Segmenter(
         }
 
         // Collect candidates above threshold; box + mask coeffs are read only for the few survivors.
-        val estimatedCapacity = (numAnchors * 0.05).toInt() // Assume ~5% will pass threshold
-        val results = ArrayList<Detection>(estimatedCapacity)
+        val detectionsByClass = arrayOfNulls<ArrayList<Detection>>(numClasses)
         val maskBase = (4 + numClasses) * numAnchors
         for (j in 0 until numAnchors) {
             val maxScore = bestScore[j]
@@ -247,18 +246,21 @@ class Segmenter(
             for (m in 0 until maskConfidenceLength) {
                 maskCoeffs[m] = detFlat[maskBase + m * numAnchors + j]
             }
-            results.add(
-                Detection(
-                    RectF(cx - w / 2f, cy - h / 2f, cx + w / 2f, cy + h / 2f),
-                    bestClass[j],
-                    maxScore,
-                    maskCoeffs
-                )
+            val detection = Detection(
+                RectF(cx - w / 2f, cy - h / 2f, cx + w / 2f, cy + h / 2f),
+                bestClass[j],
+                maxScore,
+                maskCoeffs
             )
+            val classDetections = detectionsByClass[detection.cls] ?: ArrayList<Detection>().also {
+                detectionsByClass[detection.cls] = it
+            }
+            classDetections.add(detection)
         }
         val finalDetections = mutableListOf<Detection>()
-        for (classIndex in 0 until numClasses) {
-            val sameClass = results.filter { it.cls == classIndex }.sortedByDescending { it.score }
+        for (sameClassUnsorted in detectionsByClass) {
+            if (sameClassUnsorted == null) continue
+            val sameClass = sameClassUnsorted.sortedByDescending { it.score }
             val picked = mutableListOf<Detection>()
             val used = BooleanArray(sameClass.size)
             for (i in sameClass.indices) {

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -33,6 +33,10 @@ class Segmenter(
     private lateinit var inputBitmap: Bitmap
     private lateinit var intValues: IntArray
 
+    // Reusable per-anchor class-argmax scratch (sized to the anchor count on first use).
+    private var classBestScore = FloatArray(0)
+    private var classBestIndex = IntArray(0)
+
     // CompiledModel output indices: detection head (rank-3) and mask proto (rank-4) may be returned in either order.
     private var detOutIndex = 0
     private var maskOutIndex = 1
@@ -193,52 +197,55 @@ class Segmenter(
         }
 
         // The detection head is flat in feature-major order: feature[f][anchor] == detFlat[f * numAnchors + anchor].
-        // Estimated capacity for results list to reduce reallocations
-        val estimatedCapacity = (numAnchors * 0.05).toInt() // Assume ~5% will pass threshold
-        val results = ArrayList<Detection>(estimatedCapacity)
-
-        // Apply early filtering - Optimization: early pruning strategy
-        val earlyThreshold = confidenceThreshold * 0.8f // Slightly lower threshold for first pass
         val classBase = 4 * numAnchors
 
-        for (j in 0 until numAnchors) {
-            // Check all classes instead of just first 3 to avoid bias
-            var quickMaxScore = 0f
-            for (c in 0 until numClasses) {
-                quickMaxScore = max(quickMaxScore, detFlat[classBase + c * numAnchors + j])
+        // Class argmax in class-major order: read each class plane (numAnchors contiguous floats) sequentially into
+        // a per-anchor running best, instead of a per-anchor scan that strides ~33 KB across the class dimension and
+        // misses cache on every step. Identical result, far friendlier memory access. The scratch buffers are reused
+        // across frames and cleared each frame — bestClass to 0 so an anchor whose class scores are all 0 still yields
+        // class 0 when it survives a zero confidence threshold, matching the pre-optimization default.
+        if (classBestScore.size < numAnchors) {
+            classBestScore = FloatArray(numAnchors)
+            classBestIndex = IntArray(numAnchors)
+        }
+        val bestScore = classBestScore
+        val bestClass = classBestIndex
+        java.util.Arrays.fill(bestScore, 0, numAnchors, 0f)
+        java.util.Arrays.fill(bestClass, 0, numAnchors, 0)
+        for (c in 0 until numClasses) {
+            val planeBase = classBase + c * numAnchors
+            for (j in 0 until numAnchors) {
+                val score = detFlat[planeBase + j]
+                if (score > bestScore[j]) {
+                    bestScore[j] = score
+                    bestClass[j] = c
+                }
             }
+        }
 
-            // Skip further processing if clearly below threshold
-            if (quickMaxScore < earlyThreshold) continue
-
-            // Continue with full processing for potential detections
+        // Collect candidates above threshold; box + mask coeffs are read only for the few survivors.
+        val estimatedCapacity = (numAnchors * 0.05).toInt() // Assume ~5% will pass threshold
+        val results = ArrayList<Detection>(estimatedCapacity)
+        val maskBase = (4 + numClasses) * numAnchors
+        for (j in 0 until numAnchors) {
+            val maxScore = bestScore[j]
+            if (maxScore < confidenceThreshold) continue
             val cx = detFlat[j]
             val cy = detFlat[numAnchors + j]
             val w = detFlat[2 * numAnchors + j]
             val h = detFlat[3 * numAnchors + j]
-            var maxScore = 0f
-            var maxClassIdx = 0
-
-            for (c in 0 until numClasses) {
-                val score = detFlat[classBase + c * numAnchors + j]
-                if (score > maxScore) {
-                    maxScore = score
-                    maxClassIdx = c
-                }
+            val maskCoeffs = FloatArray(maskConfidenceLength)
+            for (m in 0 until maskConfidenceLength) {
+                maskCoeffs[m] = detFlat[maskBase + m * numAnchors + j]
             }
-
-            if (maxScore >= confidenceThreshold) {
-                val maskCoeffs = FloatArray(maskConfidenceLength)
-                val base = (4 + numClasses) * numAnchors
-                for (m in 0 until maskConfidenceLength) {
-                    maskCoeffs[m] = detFlat[base + m * numAnchors + j]
-                }
-                val left = cx - w / 2f
-                val top = cy - h / 2f
-                val right = cx + w / 2f
-                val bottom = cy + h / 2f
-                results.add(Detection(RectF(left, top, right, bottom), maxClassIdx, maxScore, maskCoeffs))
-            }
+            results.add(
+                Detection(
+                    RectF(cx - w / 2f, cy - h / 2f, cx + w / 2f, cy + h / 2f),
+                    bestClass[j],
+                    maxScore,
+                    maskCoeffs
+                )
+            )
         }
         val finalDetections = mutableListOf<Detection>()
         for (classIndex in 0 until numClasses) {

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -5,6 +5,8 @@ package com.ultralytics.yolo
 import android.content.Context
 import android.graphics.*
 import android.util.Log
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -39,6 +41,10 @@ class Segmenter(
 
     // Reusable per-pixel accumulator for NCHW mask generation (sized to the proto plane on first use).
     private var maskAccum = FloatArray(0)
+    private var combinedMaskPixels = IntArray(0)
+    private var scaledX0 = IntArray(0)
+    private var scaledX1 = IntArray(0)
+    private var scaledXWeight = FloatArray(0)
 
     // CompiledModel output indices: detection head (rank-3) and mask proto (rank-4) may be returned in either order.
     private var detOutIndex = 0
@@ -328,7 +334,14 @@ class Segmenter(
         if (maskW <= 0 || maskH <= 0 || maskC <= 0) return Pair(null, null)
         val contentRect = modelMaskCropRect(maskW, maskH, origWidth, origHeight)
             ?: Rect(0, 0, maskW, maskH)
-        val combinedPixels = IntArray(maskW * maskH) { Color.TRANSPARENT }
+        val targetWidth = max(1, (contentRect.width().toFloat() / maskW * modelInputSize.first).roundToInt())
+        val targetHeight = max(1, (contentRect.height().toFloat() / maskH * modelInputSize.second).roundToInt())
+        val displayScaleX = targetWidth.toFloat() / contentRect.width()
+        val displayScaleY = targetHeight.toFloat() / contentRect.height()
+        val pixelCount = targetWidth * targetHeight
+        if (combinedMaskPixels.size < pixelCount) combinedMaskPixels = IntArray(pixelCount)
+        val combinedPixels = combinedMaskPixels
+        java.util.Arrays.fill(combinedPixels, 0, pixelCount, Color.TRANSPARENT)
         val probabilityMasks = if (returnIndividualMasks) mutableListOf<List<List<Float>>>() else null
         val coeffCount = min(maskConfidenceLength, maskC)
         detections.forEach { det ->
@@ -362,6 +375,16 @@ class Segmenter(
             }
             // proto flat layout: NHWC -> protoFlat[(y*maskW + x)*maskC + c]; NCHW -> protoFlat[c*planeSize + y*maskW + x].
             val planeSize = maskH * maskW
+            val targetLeft = max(0, floor((outputBox.left - contentRect.left) * displayScaleX).toInt())
+            val targetTop = max(0, floor((outputBox.top - contentRect.top) * displayScaleY).toInt())
+            val targetRight = min(targetWidth, ceil((outputBox.right - contentRect.left) * displayScaleX).toInt())
+            val targetBottom = min(targetHeight, ceil((outputBox.bottom - contentRect.top) * displayScaleY).toInt())
+            if (targetLeft >= targetRight || targetTop >= targetBottom) {
+                instanceMask?.let { mask ->
+                    probabilityMasks?.add(mask.map { it.toList() })
+                }
+                return@forEach
+            }
             if (protoNchw) {
                 // Plane-major accumulation for the NCHW proto: stream each coeff's proto plane over the box into a
                 // per-pixel accumulator (cache-friendly), instead of gathering coeffCount planeSize-strided reads per
@@ -390,13 +413,30 @@ class Segmenter(
                         val pix = rowBase + x
                         val v = acc[pix]
                         if (v > threshold) {
-                            combinedPixels[pix] = color
                             instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
                         }
                     }
                 }
+                paintScaledMask(
+                    logits = acc,
+                    sourceWidth = maskW,
+                    sourceBox = outputBox,
+                    contentRect = contentRect,
+                    targetLeft = targetLeft,
+                    targetTop = targetTop,
+                    targetRight = targetRight,
+                    targetBottom = targetBottom,
+                    scaleX = displayScaleX,
+                    scaleY = displayScaleY,
+                    threshold = threshold,
+                    color = color,
+                    pixels = combinedPixels,
+                    targetWidth = targetWidth
+                )
             } else {
                 // NHWC proto: classes are contiguous per pixel, so the per-pixel dot product already streams cache lines.
+                if (maskAccum.size < planeSize) maskAccum = FloatArray(planeSize)
+                val acc = maskAccum
                 for (y in outputBox.top until outputBox.bottom) {
                     val rowBase = y * maskW
                     for (x in outputBox.left until outputBox.right) {
@@ -406,36 +446,88 @@ class Segmenter(
                         for (c in 0 until coeffCount) {
                             v += det.maskCoeffs[c] * protoFlat[base + c]
                         }
+                        acc[pix] = v
                         if (v > threshold) {
-                            combinedPixels[pix] = color
                             instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
                         }
                     }
                 }
+                paintScaledMask(
+                    logits = acc,
+                    sourceWidth = maskW,
+                    sourceBox = outputBox,
+                    contentRect = contentRect,
+                    targetLeft = targetLeft,
+                    targetTop = targetTop,
+                    targetRight = targetRight,
+                    targetBottom = targetBottom,
+                    scaleX = displayScaleX,
+                    scaleY = displayScaleY,
+                    threshold = threshold,
+                    color = color,
+                    pixels = combinedPixels,
+                    targetWidth = targetWidth
+                )
             }
             instanceMask?.let { mask ->
                 probabilityMasks?.add(mask.map { it.toList() })
             }
         }
-        val bmp = Bitmap.createBitmap(maskW, maskH, Bitmap.Config.ARGB_8888)
-        bmp.setPixels(combinedPixels, 0, maskW, 0, 0, maskW, maskH)
-        val croppedBmp = if (
-            contentRect.left == 0 &&
-            contentRect.top == 0 &&
-            contentRect.right == maskW &&
-            contentRect.bottom == maskH
-        ) {
-            bmp
-        } else {
-            Bitmap.createBitmap(
-                bmp,
-                contentRect.left,
-                contentRect.top,
-                contentRect.width(),
-                contentRect.height()
-            ).also { bmp.recycle() }
+        val bmp = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        bmp.setPixels(combinedPixels, 0, targetWidth, 0, 0, targetWidth, targetHeight)
+        return Pair(bmp, probabilityMasks)
+    }
+
+    private fun paintScaledMask(
+        logits: FloatArray,
+        sourceWidth: Int,
+        sourceBox: Rect,
+        contentRect: Rect,
+        targetLeft: Int,
+        targetTop: Int,
+        targetRight: Int,
+        targetBottom: Int,
+        scaleX: Float,
+        scaleY: Float,
+        threshold: Float,
+        color: Int,
+        pixels: IntArray,
+        targetWidth: Int
+    ) {
+        val columnCount = targetRight - targetLeft
+        if (scaledX0.size < columnCount) {
+            scaledX0 = IntArray(columnCount)
+            scaledX1 = IntArray(columnCount)
+            scaledXWeight = FloatArray(columnCount)
         }
-        return Pair(croppedBmp, probabilityMasks)
+        for (i in 0 until columnCount) {
+            val sourceX = contentRect.left + (targetLeft + i + 0.5f) / scaleX - 0.5f
+            val x0 = floor(sourceX).toInt().coerceIn(sourceBox.left, sourceBox.right - 1)
+            scaledX0[i] = x0
+            scaledX1[i] = min(x0 + 1, sourceBox.right - 1)
+            scaledXWeight[i] = (sourceX - x0).coerceIn(0f, 1f)
+        }
+
+        for (ty in targetTop until targetBottom) {
+            val sourceY = contentRect.top + (ty + 0.5f) / scaleY - 0.5f
+            val y0 = floor(sourceY).toInt().coerceIn(sourceBox.top, sourceBox.bottom - 1)
+            val y1 = min(y0 + 1, sourceBox.bottom - 1)
+            val yWeight = (sourceY - y0).coerceIn(0f, 1f)
+            val row0 = y0 * sourceWidth
+            val row1 = y1 * sourceWidth
+            var pixelIndex = ty * targetWidth + targetLeft
+            for (i in 0 until columnCount) {
+                val x0 = scaledX0[i]
+                val x1 = scaledX1[i]
+                val xWeight = scaledXWeight[i]
+                val top = logits[row0 + x0] * (1f - xWeight) + logits[row0 + x1] * xWeight
+                val bottom = logits[row1 + x0] * (1f - xWeight) + logits[row1 + x1] * xWeight
+                if (top * (1f - yWeight) + bottom * yWeight > threshold) {
+                    pixels[pixelIndex] = color
+                }
+                pixelIndex++
+            }
+        }
     }
 
     private fun maskBoxForDetection(outputBox: RectF, maskW: Int, maskH: Int): Rect {

--- a/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
@@ -176,7 +176,7 @@ class SemanticSegmenter(
 
         val maskImage = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         maskImage.setPixels(pixels, 0, width, 0, 0, width, height)
-        return SemanticMask(classMap.toList(), width, height, maskImage)
+        return SemanticMask(classMap, width, height, maskImage)
     }
 
     private fun semanticColors(classCount: Int): IntArray {

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLO.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLO.kt
@@ -375,21 +375,21 @@ class YOLO(
                         mask,
                         output.width,
                         output.height,
-                        true
+                        false
                     )
                     paint.style = Paint.Style.FILL
                     paint.alpha = 128
-                    paint.isFilterBitmap = true
+                    paint.isFilterBitmap = false
                     canvas.drawBitmap(maskScaled, 0f, 0f, paint)
                     if (maskScaled !== mask) maskScaled.recycle()
                 }
             }
             YOLOTask.SEMANTIC -> {
                 result.semanticMask?.maskImage?.let { mask ->
-                    val maskScaled = Bitmap.createScaledBitmap(mask, output.width, output.height, true)
+                    val maskScaled = Bitmap.createScaledBitmap(mask, output.width, output.height, false)
                     paint.style = Paint.Style.FILL
                     paint.alpha = 128
-                    paint.isFilterBitmap = true
+                    paint.isFilterBitmap = false
                     canvas.drawBitmap(maskScaled, 0f, 0f, paint)
                     paint.alpha = 255
                     if (maskScaled !== mask) maskScaled.recycle()

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
@@ -279,7 +279,7 @@ class YOLOPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCallHandler
               YOLOTask.SEMANTIC -> {
                 yoloResult.semanticMask?.let { semanticMask ->
                   response["semanticMask"] = mapOf(
-                    "classMap" to semanticMask.classMap,
+                    "classMap" to semanticMask.classMap.toList(),
                     "width" to semanticMask.width,
                     "height" to semanticMask.height
                   )

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOResult.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOResult.kt
@@ -38,7 +38,7 @@ data class Masks(
 )
 
 data class SemanticMask(
-    val classMap: List<Int>,
+    val classMap: IntArray,
     val width: Int,
     val height: Int,
     val maskImage: Bitmap?

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -1746,7 +1746,7 @@ class YOLOView @JvmOverloads constructor(
                         val src = Rect(0, 0, maskBitmap.width, maskBitmap.height)
                         val maskPaint = Paint().apply {
                             alpha = 128
-                            isFilterBitmap = true
+                            isFilterBitmap = false
                         }
                         
                         if (isFrontCamera) {
@@ -1771,7 +1771,7 @@ class YOLOView @JvmOverloads constructor(
                         val src = Rect(0, 0, maskBitmap.width, maskBitmap.height)
                         val maskPaint = Paint().apply {
                             alpha = 128
-                            isFilterBitmap = true
+                            isFilterBitmap = false
                         }
 
                         if (isFrontCamera) {

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -2239,7 +2239,7 @@ class YOLOView @JvmOverloads constructor(
         if (config.includeMasks) {
             result.semanticMask?.let { semanticMask ->
                 map["semanticMask"] = mapOf(
-                    "classMap" to semanticMask.classMap,
+                    "classMap" to semanticMask.classMap.toList(),
                     "width" to semanticMask.width,
                     "height" to semanticMask.height
                 )

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -119,6 +119,17 @@ what worked, and what's left on the table:
 - **In-graph ArgMax semantic QNN exports** (ultralytics#24790): a uint8 class map replaces ~80 MB of float logits;
   stable ~50 ms vs 123-1065 ms (erratic) before.
 - **GPU program cache** (`GpuOptions.serializationDir`): model re-opens skip OpenCL compilation.
+- **Cache-local segment decode** (#549): the class-argmax over the `[1, 4+nc+32, 8400]` head read each class
+  ~33 KB apart — a cache miss per class per anchor. Reorganized to class-major (each class plane streamed
+  sequentially into a per-anchor running best) and dropped a redundant early-reject scan. Segment postprocess
+  ~9.6 → 7.3 ms (**−24%**) on the 80-class model, output bit-identical (matching detection counts before/after). The
+  win scales with class count: an isolated 20-class decode dropped −57%, 1-class is within noise (so custom
+  few-class models never regress).
+- **Cache-local segment mask generation** (#549): the NCHW mask `Σ coeff·proto` gathered 32 proto values
+  `planeSize` (~102 KB) apart per pixel. Reorganized to plane-major accumulation — stream each proto plane over the
+  detection box into a reused per-pixel accumulator. A further **−1.2 ms / −13%** off segment postprocess
+  (thermally matched at ~22 ms inference), bit-identical. NHWC (legacy onnx2tf) proto is already pixel-contiguous
+  and was left unchanged.
 
 **Tested and intentionally NOT changed (don't re-litigate without new evidence):**
 
@@ -134,6 +145,11 @@ what worked, and what's left on the table:
   37.6 ms for GPU logits + the app's NHWC argmax. The class-map export stays QNN/Core ML-only.
 - **int32 class maps**: uint8 quarters the NPU→CPU output transfer and every consumer reads it (Core ML promotes
   it to int32 in-spec); int32 indices are reserved for >256-class models. uint8 stays the class-map dtype.
+- **Class-major argmax for detect / OBB decode**: the cache reorganization that won on segment (above) showed no
+  benefit on detect — already native C++, where the JNI `GetFloatArrayElements` copy of the ~705k-float output
+  dominates, not the argmax — and a slight regression on OBB, which has only ~15 classes so the per-frame buffer
+  clear plus extra pass outweighs the small cache gain. Both reverted: the win needs *both* many classes and the
+  Kotlin path. Semantic argmax was already class-major (NCHW logits), so it was already optimal.
 
 **Future exploration (in expected-value order):**
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -148,7 +148,7 @@ what worked, and what's left on the table:
 - **Class-major argmax for detect / OBB decode**: the cache reorganization that won on segment (above) showed no
   benefit on detect — already native C++, where the JNI `GetFloatArrayElements` copy of the ~705k-float output
   dominates, not the argmax — and a slight regression on OBB, which has only ~15 classes so the per-frame buffer
-  clear plus extra pass outweighs the small cache gain. Both reverted: the win needs *both* many classes and the
+  clear plus extra pass outweighs the small cache gain. Both reverted: the win needs _both_ many classes and the
   Kotlin path. Semantic argmax was already class-major (NCHW logits), so it was already optimal.
 
 **Future exploration (in expected-value order):**

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -136,6 +136,10 @@ what worked, and what's left on the table:
   reduced the Xiaomi 17 GPU path to **7.6-8.6 ms postprocess** for `yolo26n-seg`, trading ~1.5-2.5 ms for
   model-resolution masks while keeping the cache-local decode/mask-gen wins above. Raw mask payloads remain at the
   existing cropped proto resolution.
+- **Postprocess overhead cleanup** (#549): classifier top-5 now uses fixed-size linear insertion instead of sorting
+  every score; semantic keeps dense class maps as `IntArray` until Flutter serialization; segment NMS buckets
+  detections once by class instead of filtering the full candidate list per class; native detect NMS stops once
+  `numItemsThreshold` boxes are kept. Outputs and Flutter payloads are unchanged.
 
 **Tested and intentionally NOT changed (don't re-litigate without new evidence):**
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -130,6 +130,10 @@ what worked, and what's left on the table:
   detection box into a reused per-pixel accumulator. A further **−1.2 ms / −13%** off segment postprocess
   (thermally matched at ~22 ms inference), bit-identical. NHWC (legacy onnx2tf) proto is already pixel-contiguous
   and was left unchanged.
+- **High-resolution segment overlays** (#549): the visible combined mask now scales logits to model-input resolution
+  before thresholding, matching the iOS SDK's sharp segment overlay path instead of upscaling a 160x160 RGBA mask.
+  On the Xiaomi 17 GPU path this measured **7.6-8.6 ms postprocess** for `yolo26n-seg`, trading ~1.5-2.5 ms for
+  model-resolution masks while keeping the cache-local decode/mask-gen wins above.
 
 **Tested and intentionally NOT changed (don't re-litigate without new evidence):**
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -132,8 +132,10 @@ what worked, and what's left on the table:
   and was left unchanged.
 - **High-resolution segment overlays** (#549): the visible combined mask now scales logits to model-input resolution
   before thresholding, matching the iOS SDK's sharp segment overlay path instead of upscaling a 160x160 RGBA mask.
-  On the Xiaomi 17 GPU path this measured **7.6-8.6 ms postprocess** for `yolo26n-seg`, trading ~1.5-2.5 ms for
-  model-resolution masks while keeping the cache-local decode/mask-gen wins above.
+  A naive Kotlin bilinear paint measured **15.5 ms postprocess** and was rejected; caching per-column interpolation
+  reduced the Xiaomi 17 GPU path to **7.6-8.6 ms postprocess** for `yolo26n-seg`, trading ~1.5-2.5 ms for
+  model-resolution masks while keeping the cache-local decode/mask-gen wins above. Raw mask payloads remain at the
+  existing cropped proto resolution.
 
 **Tested and intentionally NOT changed (don't re-litigate without new evidence):**
 

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "b4aab348f2ef208083ceac056ffbecd3449a7e78",
-        "version" : "8.9.7"
+        "revision" : "2032fe44e6f93113497df9ffe8c5fab9e4ee1c9d",
+        "version" : "8.9.10"
       }
     }
   ],

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "b4aab348f2ef208083ceac056ffbecd3449a7e78",
-        "version" : "8.9.7"
+        "revision" : "2032fe44e6f93113497df9ffe8c5fab9e4ee1c9d",
+        "version" : "8.9.10"
       }
     }
   ],

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -19,7 +19,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # "no rule to process file ... net.daringfireball.markdown" warning Xcode emits when README.md is swept in.
   s.source_files = 'ultralytics_yolo/Sources/ultralytics_yolo/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.5', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.10', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/ultralytics_yolo/Package.swift
+++ b/ios/ultralytics_yolo/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   ],
   dependencies: [
     // Shared YOLO inference core, the single source of truth for iOS (https://github.com/ultralytics/yolo-ios-app).
-    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.5', '< 9.0'` range in the podspec.
-    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.5"..<"9.0.0")
+    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.10', '< 9.0'` range in the podspec.
+    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.10"..<"9.0.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
## What

Speeds up the Android **segment** post-processing decode by reading the detection head's class scores in **class-major order** instead of the previous per-anchor scan that strides across the class dimension.

The detection head is laid out feature-major (`detFlat[f * numAnchors + anchor]`), so the old per-anchor argmax read each class `~33 KB` apart — a cache miss on every one of `numAnchors × numClasses` reads — and additionally scanned all classes twice (an early-reject pass plus the argmax pass). The new decode walks each class plane sequentially into reused per-anchor `bestScore`/`bestClass` scratch buffers, then collects survivors in a single pass, reading box + mask coefficients only for anchors above threshold.

## Output is unchanged

Same per-anchor argmax with identical tie-breaking (lowest class index wins). Both scratch buffers are cleared each frame so an all-zero-score anchor surviving a zero confidence threshold still resolves to class 0, exactly as before. Verified by matching detection counts before/after across 1-, 20-, and 80-class models.

## Measured (Snapdragon 8 Elite Gen 5, Adreno GPU, w8a32 `yolo26n-seg`, 640², 40 runs)

| Workload | classes | post before | post after | Δ |
| --- | --- | --- | --- | --- |
| `yolo26n-seg` full post | 80 | ~9.6 ms | ~7.3 ms | **−24%** |
| decode scan, isolated | 20 | 1.16 ms | 0.50 ms | **−57%** |
| decode scan, isolated | 1 | 0.08 ms | 0.09 ms | within noise |

The win scales with class count and never regresses: an extra per-frame `int[]` clear (~µs) is the only added cost, so few-class custom models are unaffected while many-class models get the full benefit. Detection counts were identical before/after for every model tested.

No API or model changes; detect/pose/OBB decode paths are untouched (they're already native or low-class-count, where the reorganization showed no benefit).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR mainly improves Android segmentation and classification performance, sharpens mask rendering, and updates iOS package dependencies for better cross-platform consistency.

### 📊 Key Changes
- ⚡ **Optimized Android segmentation postprocessing**:
  - Reworked class selection and mask generation to use more cache-friendly memory access.
  - Reused scratch buffers to reduce repeated allocations.
  - Removed redundant filtering passes and grouped detections by class earlier for faster NMS.
- 🎭 **Sharper segmentation overlays**:
  - Segment masks are now scaled more intelligently before thresholding, producing cleaner, higher-resolution overlays.
  - Bitmap filtering was disabled in several rendering paths to preserve mask sharpness.
- 🧠 **Faster classifier top-k selection**:
  - Replaced full score sorting with a lightweight fixed-size top-5 selection approach.
- 📦 **Lower-overhead semantic mask handling**:
  - `SemanticMask.classMap` now stays as an `IntArray` internally instead of converting immediately to a list.
  - Conversion to Flutter-friendly lists now happens only when serializing results.
- 🛑 **Improved native detection NMS**:
  - Android native NMS now stops early once the requested maximum number of detections is reached.
- 🍎 **Updated iOS dependency versions**:
  - Bumped the shared `UltralyticsYOLO` iOS dependency from `8.9.5/8.9.7` to `8.9.10`.

### 🎯 Purpose & Impact
- 🚀 **Faster inference pipeline on Android**, especially for segmentation models with many classes.
- 🎨 **Better visual quality** for segmentation overlays, with crisper masks that look closer to model-resolution output.
- 📉 **Reduced CPU and memory overhead**, which can help responsiveness and efficiency on mobile devices.
- 🔄 **No intended API or output-format changes for Flutter users**, aside from internal efficiency improvements and equivalent serialization behavior.
- 🍏 **Better iOS/Android alignment** through updated shared dependencies, helping keep behavior more consistent across platforms.