### PR TITLE
Skip dead mask loop and send semantic class map as Int32List

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -409,13 +409,14 @@ class Segmenter(
                         }
                     }
                 }
-                for (y in outputBox.top until outputBox.bottom) {
-                    val rowBase = y * maskW
-                    for (x in outputBox.left until outputBox.right) {
-                        val pix = rowBase + x
-                        val v = acc[pix]
-                        if (v > threshold) {
-                            instanceMask?.get(y - contentRect.top)?.set(x - contentRect.left, v)
+                if (instanceMask != null) {
+                    for (y in outputBox.top until outputBox.bottom) {
+                        val rowBase = y * maskW
+                        for (x in outputBox.left until outputBox.right) {
+                            val v = acc[rowBase + x]
+                            if (v > threshold) {
+                                instanceMask.get(y - contentRect.top)?.set(x - contentRect.left, v)
+                            }
                         }
                     }
                 }

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOPlugin.kt
@@ -279,7 +279,9 @@ class YOLOPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCallHandler
               YOLOTask.SEMANTIC -> {
                 yoloResult.semanticMask?.let { semanticMask ->
                   response["semanticMask"] = mapOf(
-                    "classMap" to semanticMask.classMap.toList(),
+                    // Send the IntArray straight through: StandardMessageCodec encodes it as a compact Int32List and
+                    // the Dart decoder reads it unchanged, avoiding a per-frame boxing copy of the dense class map.
+                    "classMap" to semanticMask.classMap,
                     "width" to semanticMask.width,
                     "height" to semanticMask.height
                   )

--- a/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/YOLOView.kt
@@ -2239,7 +2239,9 @@ class YOLOView @JvmOverloads constructor(
         if (config.includeMasks) {
             result.semanticMask?.let { semanticMask ->
                 map["semanticMask"] = mapOf(
-                    "classMap" to semanticMask.classMap.toList(),
+                    // Send the IntArray straight through: StandardMessageCodec encodes it as a compact Int32List and
+                    // the Dart decoder reads it unchanged, avoiding a per-frame boxing copy of the dense class map.
+                    "classMap" to semanticMask.classMap,
                     "width" to semanticMask.width,
                     "height" to semanticMask.height
                 )

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -140,6 +140,10 @@ what worked, and what's left on the table:
   every score; semantic keeps dense class maps as `IntArray` until Flutter serialization; segment NMS buckets
   detections once by class instead of filtering the full candidate list per class; native detect NMS stops once
   `numItemsThreshold` boxes are kept. Outputs and Flutter payloads are unchanged.
+- **Postprocess follow-ups** (#550): the model-resolution mask skips its per-instance probability-mask loop entirely
+  on the default path (raw masks not requested) instead of scanning each detection box for a no-op; the semantic
+  class map is sent to Flutter as a compact `Int32List` rather than a boxed `List<Int>` copy, dropping a per-frame
+  copy of the dense map (decoded identically on the Dart side). Outputs unchanged.
 
 **Tested and intentionally NOT changed (don't re-litigate without new evidence):**
 


### PR DESCRIPTION
## What

Two Android postprocessing follow-ups to the segment/semantic work merged in #549, found while going back over that diff.

### 1. Skip the dead instance-mask loop in `generateCombinedMaskImage`

Rendering the mask at model resolution moved the combined-mask write into `paintScaledMask`, leaving the NCHW post-accumulation loop responsible only for filling the optional per-instance probability mask. When raw masks aren't requested (`returnIndividualMasks == false` — the default camera path), that loop scanned the entire detection box for a no-op. It now runs only when the instance mask is actually being built.

### 2. Send the semantic `classMap` as a typed `Int32List`

The dense semantic class map was copied to a boxed `List<Int>` (`.toList()`) at both serialization sites. Passing the `IntArray` straight through lets `StandardMessageCodec` encode it as a compact `Int32List`, dropping a per-frame boxing copy of the whole class map and shrinking the wire payload. The Dart decoder (`YOLOSemanticMask.fromMap` → `as List<dynamic>` → `whereType<num>()`) reads the `Int32List` unchanged, so no Dart-side change is needed.

## Validation

- `flutter analyze` and `flutter test` (173 tests) pass.
- Outputs are unchanged: change 1 is a pure no-op skip in the common path; change 2 changes only the wire encoding of `classMap` (typed array vs boxed list), decoded identically on the Dart side.
- Worth a quick on-device semantic sanity-check before merge given the `classMap` wire-type change.

Android-only; detect / pose / OBB / classify paths are untouched.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Android postprocessing performance for segmentation and semantic outputs without changing app-visible results 🚀

### 📊 Key Changes
- Skips unnecessary per-instance mask scanning in `Segmenter.kt` when raw instance masks are not requested 🧩
- Sends semantic segmentation `classMap` as a native `IntArray` instead of converting it to a boxed `List<Int>` 📦➡️⚡
- Applies the `IntArray` optimization in both `YOLOPlugin.kt` and `YOLOView.kt` for consistent Flutter output handling
- Updates `doc/performance.md` to document these postprocessing optimizations and confirm outputs remain unchanged 📝

### 🎯 Purpose & Impact
- Reduces avoidable per-frame CPU work during segmentation postprocessing, especially on Android 📱
- Lowers memory allocation and copy overhead for dense semantic masks by using Flutter’s compact `Int32List` encoding
- Maintains the same Dart-side behavior and output structure, so users should not need to change app code ✅
- Helps improve real-time YOLO app responsiveness and efficiency, particularly for segmentation-heavy workloads 🎯