### PR TITLE
Drop iOS Core ML models from the Android bundle

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.6+13
+version: 0.6.6+14
 
 environment:
   sdk: ^3.8.1

--- a/play-store-assets/README.md
+++ b/play-store-assets/README.md
@@ -41,6 +41,10 @@ name, builds the signed release bundle from `example/`, verifies the AAB signatu
 
 If `ultralytics-yolo-feature-graphic.png` is present, the script preserves it and includes it in the checksum file.
 
+The Android bundle ships only the nano `*_w8a32.tflite` models. The iOS Core ML packages (`*.mlpackage.zip`) that
+`assets/models/` also holds for local convenience are pruned from the build by `scripts/fetch_bundled_models.sh` (which
+keeps the folder single-platform), so they don't bloat the per-device download.
+
 After a successful run, this directory should look like:
 
 ```text

--- a/scripts/fetch_bundled_models.sh
+++ b/scripts/fetch_bundled_models.sh
@@ -63,9 +63,11 @@ IOS_FILES=(
 if [ "$PLATFORM" = "android" ]; then
   BASE="$ANDROID_BASE"
   FILES=("${ANDROID_FILES[@]}")
+  OTHER_FILES=("${IOS_FILES[@]}")
 else
   BASE="$IOS_BASE"
   FILES=("${IOS_FILES[@]}")
+  OTHER_FILES=("${ANDROID_FILES[@]}")
 fi
 
 mkdir -p "$DEST"
@@ -102,14 +104,13 @@ for f in "${FILES[@]}"; do
   fetch "$f"
 done
 
-# Keep assets/models/ single-platform: Flutter bundles the whole folder, so the other platform's models would
+# Keep assets/models/ single-platform: Flutter bundles the whole folder, so the other platform's bundled models would
 # otherwise ship in this build — e.g. the iOS Core ML packages (~14 MB) are dead weight in the Android APK and never
-# loaded. The folder is gitignored and re-fetched on demand, so pruning the wrong-platform files here is safe.
-if [ "$PLATFORM" = "android" ]; then
-  rm -f "$DEST"/*.mlpackage.zip
-else
-  rm -f "$DEST"/*.tflite
-fi
+# loaded. Only the known auto-fetched filenames are removed (re-fetched on demand), so any custom or benchmark model a
+# developer dropped into assets/models/ is left untouched.
+for f in "${OTHER_FILES[@]}"; do
+  rm -f "$DEST/$f"
+done
 
 # Always succeed: bundling is an optimization, never a hard build dependency.
 exit 0

--- a/scripts/fetch_bundled_models.sh
+++ b/scripts/fetch_bundled_models.sh
@@ -102,5 +102,14 @@ for f in "${FILES[@]}"; do
   fetch "$f"
 done
 
+# Keep assets/models/ single-platform: Flutter bundles the whole folder, so the other platform's models would
+# otherwise ship in this build — e.g. the iOS Core ML packages (~14 MB) are dead weight in the Android APK and never
+# loaded. The folder is gitignored and re-fetched on demand, so pruning the wrong-platform files here is safe.
+if [ "$PLATFORM" = "android" ]; then
+  rm -f "$DEST"/*.mlpackage.zip
+else
+  rm -f "$DEST"/*.tflite
+fi
+
 # Always succeed: bundling is an optimization, never a hard build dependency.
 exit 0


### PR DESCRIPTION
## What

`example/assets/models/` holds both the Android `*_w8a32.tflite` and iOS `*.mlpackage.zip` nano models for local convenience, and Flutter bundles the whole folder — so **~14 MB of iOS Core ML packages were shipping in the Android APK/AAB**, where they are never loaded (Android runs LiteRT/tflite).

`scripts/fetch_bundled_models.sh` is already platform-specific (Android fetches `*_w8a32.tflite`, iOS fetches `*.mlpackage.zip`). It now also prunes the *other* platform's models so `assets/models/` stays single-platform for the build. The folder is gitignored and re-fetched on demand, so pruning is safe and self-healing.

This was the only mechanism that reliably worked — `aaptOptions.ignoreAssetsPattern` does **not** filter Flutter assets (they're added to the merge after aapt's asset-ignore step), confirmed by inspecting the APK.

## Impact

- **Per-device Play install: ~40 MB → ~26 MB** (no QNN, 6 nano tflite models, one CPU ABI).
- No functional change — the Core ML packages were dead weight on Android.

## Also

- Bumps the example build number to **0.6.6+14** for the next Play upload (build 13 is already uploaded, so the versionCode must increment).
- `play-store-assets/README.md` documents the single-platform bundling.

## Verification

Rebuilt the signed release AAB and confirmed it bundles the 6 `*_w8a32.tflite` models and **zero** `*.mlpackage.zip` (size numbers posted below). CI's `example-android` exercises the runtime-download path (bundling is skipped under CI), so it's unaffected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves bundled model handling so Android and iOS builds only include the models they actually need, reducing app download size 📦✨

### 📊 Key Changes
- Bumped the example app version from `0.6.6+13` to `0.6.6+14` 🚀
- Updated Play Store asset documentation to clarify that Android bundles only nano `*_w8a32.tflite` models 📱
- Enhanced `scripts/fetch_bundled_models.sh` to remove auto-fetched models for the opposite platform during build cleanup 🧹
- Preserves custom or benchmark models placed in `assets/models/`, only deleting known auto-fetched bundled files ✅

### 🎯 Purpose & Impact
- Reduces Android APK/AAB size by excluding unused iOS Core ML model packages 🎯
- Keeps `assets/models/` platform-specific during builds, avoiding unnecessary bundled assets ⚙️
- Improves app store delivery efficiency with smaller per-device downloads 📉
- Maintains developer flexibility by leaving manually added custom models untouched 🛠️