### PR TITLE
Speed up Android preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.8
+
+- **Performance**: Speed up Android single-image preprocessing for NCHW LiteRT/QNN models by writing planar CHW input
+  directly during RGB packing and clearing only real letterbox padding. Refresh the LiteRT/TFLite benchmark tables with
+  the current Xiaomi 17 measurements, while documenting that live camera preprocessing still includes per-frame
+  CameraX rotation and letterbox work.
+- **Enhancement**: Require UltralyticsYOLO `>= 8.9.11` on iOS through both CocoaPods and Swift Package Manager.
+
 ## 0.6.7
 
 - **Fix**: iOS share/capture composites overlays by lifting the live preview sublayers above the frozen frame instead of reconstructing them, so segmentation masks and pose keypoints now appear in shared images, oriented (OBB) boxes keep their rotation, and overlays stay below the on-screen controls. Simplifies `renderShareImage` to mirror the upstream YOLO iOS implementation.

--- a/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Classifier.kt
@@ -99,7 +99,14 @@ class Classifier(
             grayBuffer.rewind()
             grayBuffer.asFloatBuffer().get(floatInput, 0, floatInput.size)
         } else {
-            ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues, INPUT_MEAN, INPUT_STD)
+            ImageUtils.copyRgbBitmapToFloatArray(
+                inputBitmap,
+                floatInput,
+                intValues,
+                INPUT_MEAN,
+                INPUT_STD,
+                channelsFirst = rtModel.inputUsesNchw
+            )
         }
 
         val preEnd = System.nanoTime()

--- a/android/src/main/kotlin/com/ultralytics/yolo/ImageUtils.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ImageUtils.kt
@@ -12,7 +12,8 @@ import kotlin.math.roundToInt
 
 object ImageUtils {
     // Shared read-only paint for frame preprocessing.
-    private val filterPaint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.DITHER_FLAG)
+    private val filterPaint = Paint(Paint.FILTER_BITMAP_FLAG)
+    private val blackPaint = Paint().apply { color = Color.BLACK }
 
     data class LetterboxTransform(
         val gain: Float,
@@ -192,7 +193,7 @@ object ImageUtils {
             ?: return targetBitmap
 
         Canvas(targetBitmap).apply {
-            drawColor(Color.BLACK)
+            clearLetterboxPadding(transform, targetWidth, targetHeight)
             save()
             translate(transform.padX + transform.resizedWidth / 2f, transform.padY + transform.resizedHeight / 2f)
             rotate(degrees.toFloat())
@@ -201,6 +202,21 @@ object ImageUtils {
             restore()
         }
         return targetBitmap
+    }
+
+    private fun Canvas.clearLetterboxPadding(
+        transform: LetterboxTransform,
+        targetWidth: Int,
+        targetHeight: Int
+    ) {
+        val left = transform.padX.coerceAtLeast(0f)
+        val top = transform.padY.coerceAtLeast(0f)
+        val right = (targetWidth - transform.padRight).coerceAtMost(targetWidth.toFloat())
+        val bottom = (targetHeight - transform.padBottom).coerceAtMost(targetHeight.toFloat())
+        if (left > 0f) drawRect(0f, 0f, left, targetHeight.toFloat(), blackPaint)
+        if (right < targetWidth) drawRect(right, 0f, targetWidth.toFloat(), targetHeight.toFloat(), blackPaint)
+        if (top > 0f) drawRect(left, 0f, right, top, blackPaint)
+        if (bottom < targetHeight) drawRect(left, bottom, right, targetHeight.toFloat(), blackPaint)
     }
 
     private fun cameraRotationDegrees(
@@ -228,7 +244,9 @@ object ImageUtils {
         byteBuffer.clear()
         bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
 
-        for (pixel in pixels) {
+        val pixelCount = bitmap.width * bitmap.height
+        for (i in 0 until pixelCount) {
+            val pixel = pixels[i]
             byteBuffer.putFloat((((pixel shr 16) and 0xFF) - inputMean) / inputStd)
             byteBuffer.putFloat((((pixel shr 8) and 0xFF) - inputMean) / inputStd)
             byteBuffer.putFloat(((pixel and 0xFF) - inputMean) / inputStd)
@@ -237,35 +255,38 @@ object ImageUtils {
     }
 
     // FloatArray variant for the LiteRT 2.x CompiledModel path (TensorBuffer.writeFloat takes a float[], not a
-    // ByteBuffer). Writes planar-free interleaved RGB, normalized to [0,1] by default. `out` must be width*height*3.
+    // ByteBuffer). Writes interleaved HWC or planar CHW RGB, normalized to [0,1] by default.
     @JvmStatic
     fun copyRgbBitmapToFloatArray(
         bitmap: Bitmap,
         out: FloatArray,
         pixels: IntArray,
         inputMean: Float = 0f,
-        inputStd: Float = 255f
+        inputStd: Float = 255f,
+        channelsFirst: Boolean = false
     ) {
         bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
-        var j = 0
-        for (pixel in pixels) {
-            out[j++] = (((pixel shr 16) and 0xFF) - inputMean) / inputStd
-            out[j++] = (((pixel shr 8) and 0xFF) - inputMean) / inputStd
-            out[j++] = ((pixel and 0xFF) - inputMean) / inputStd
-        }
-    }
-
-    // Transpose interleaved HWC RGB floats (r,g,b,r,g,b,...) into planar CHW (all R, then all G, then all B) in `dst`.
-    // Shared by the NCHW inference backends (LiteRT litert-torch, ONNX/QNN); `dst` must match `src` length (w*h*3).
-    @JvmStatic
-    fun hwcToChw(src: FloatArray, dst: FloatArray) {
-        val n = src.size / 3
-        var j = 0
-        for (i in 0 until n) {
-            dst[i] = src[j]
-            dst[n + i] = src[j + 1]
-            dst[2 * n + i] = src[j + 2]
-            j += 3
+        val pixelCount = bitmap.width * bitmap.height
+        val invStd = 1f / inputStd
+        if (channelsFirst) {
+            val plane = pixelCount
+            var r = 0
+            var g = plane
+            var b = plane * 2
+            for (i in 0 until pixelCount) {
+                val pixel = pixels[i]
+                out[r++] = (((pixel shr 16) and 0xFF) - inputMean) * invStd
+                out[g++] = (((pixel shr 8) and 0xFF) - inputMean) * invStd
+                out[b++] = ((pixel and 0xFF) - inputMean) * invStd
+            }
+        } else {
+            var j = 0
+            for (i in 0 until pixelCount) {
+                val pixel = pixels[i]
+                out[j++] = (((pixel shr 16) and 0xFF) - inputMean) * invStd
+                out[j++] = (((pixel shr 8) and 0xFF) - inputMean) * invStd
+                out[j++] = ((pixel and 0xFF) - inputMean) * invStd
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
@@ -24,8 +24,7 @@ import kotlin.math.sqrt
  *
  * Input layout is detected from the input tensor shape: legacy onnx2tf exports are NHWC `[1,H,W,3]`, while
  * `format=litert` (litert-torch) exports are NCHW `[1,3,H,W]`. [inputDims] is always reported in the NHWC convention so
- * predictors stay layout-agnostic (matching [OrtQnnModel]); [run] feeds interleaved HWC floats, transposing them to
- * planar CHW internally for NCHW models.
+ * predictors stay layout-agnostic (matching [OrtQnnModel]); [inputUsesNchw] tells them when to write CHW directly.
  */
 class LiteRtModel(
     private val context: android.content.Context,
@@ -50,10 +49,7 @@ class LiteRtModel(
     private val outputTypes: List<TensorType.ElementType?>
 
     /** True when the model input is NCHW `[1,3,H,W]` (litert-torch) rather than NHWC `[1,H,W,3]` (legacy onnx2tf). */
-    private val nchw: Boolean
-
-    /** Reusable planar CHW scratch buffer for NCHW models, allocated once to avoid per-frame churn (see [run]). */
-    private var chwScratch = FloatArray(0)
+    override val inputUsesNchw: Boolean
 
     /** Accelerator actually in use after the ladder resolves: "GPU" or "CPU". */
     override val accelerator: String
@@ -91,7 +87,7 @@ class LiteRtModel(
         inputBuffers = prepared.inputBuffers
         outputBuffers = prepared.outputBuffers
         inputDims = prepared.inputDims
-        nchw = prepared.nchw
+        inputUsesNchw = prepared.nchw
         outputElementCounts = prepared.outputElementCounts
         outputDims = prepared.outputDims
         outputTypes = prepared.outputTypes
@@ -153,7 +149,7 @@ class LiteRtModel(
                     }
                 }
             // litert-torch exports are NCHW [1,3,H,W]; legacy onnx2tf exports are NHWC [1,H,W,3]. Detect from the shape
-            // and report NHWC to predictors either way so they stay layout-agnostic (run() transposes for NCHW).
+            // and report NHWC to predictors either way so they stay layout-agnostic.
             val nchw = nativeDims.size >= 4 && nativeDims[1] == 3 && nativeDims.last() != 3
             val dims = if (nchw) intArrayOf(nativeDims[0], nativeDims[2], nativeDims[3], 3) else nativeDims
 
@@ -191,18 +187,11 @@ class LiteRtModel(
     }
 
     /**
-     * Run inference: write [input] floats (interleaved HWC, as the predictors produce) into the first input buffer, run,
-     * and return each output as a flat float array. NCHW models get an HWC→CHW transpose first.
+     * Run inference: write [input] floats in the model's native layout into the first input buffer, run, and return
+     * each output as a flat float array.
      */
     override fun run(input: FloatArray): List<FloatArray> {
-        val buffer = if (nchw) {
-            if (chwScratch.size != input.size) chwScratch = FloatArray(input.size)
-            ImageUtils.hwcToChw(input, chwScratch)
-            chwScratch
-        } else {
-            input
-        }
-        inputBuffers[0].writeFloat(buffer)
+        inputBuffers[0].writeFloat(input)
         model.run(inputBuffers, outputBuffers)
         return List(outputBuffers.size) { readAsFloats(outputBuffers[it], outputTypes[it]) }
     }

--- a/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObbDetector.kt
@@ -74,7 +74,12 @@ class ObbDetector(
             isFrontCamera = isFrontCamera,
             rotationDegrees = cameraRotationDegrees
         )
-        ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
+        ImageUtils.copyRgbBitmapToFloatArray(
+            inputBitmap,
+            floatInput,
+            intValues,
+            channelsFirst = rtModel.inputUsesNchw
+        )
 
         val preEnd = System.nanoTime()
         val flat = rtModel.run(floatInput)[0]

--- a/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/ObjectDetector.kt
@@ -105,7 +105,8 @@ class ObjectDetector(
             floatInput,
             intValues,
             INPUT_MEAN,
-            INPUT_STANDARD_DEVIATION
+            INPUT_STANDARD_DEVIATION,
+            channelsFirst = rtModel.inputUsesNchw
         )
 
         // ======== Inference ============

--- a/android/src/main/kotlin/com/ultralytics/yolo/OrtQnnModel.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/OrtQnnModel.kt
@@ -21,8 +21,8 @@ import java.nio.FloatBuffer
  * architecture at export time, so the session loads without on-device graph compilation - and without a CPU
  * fallback: on non-Snapdragon hardware session creation throws and callers should fall back to a TFLite model.
  *
- * Predictors supply NHWC interleaved-RGB floats (the TFLite layout); this wrapper transposes into the NCHW planar
- * layout ONNX models expect and reports [inputDims] in the NHWC convention so predictors stay runtime-agnostic.
+ * Reports [inputDims] in the NHWC convention so predictors stay runtime-agnostic. [inputUsesNchw] tells predictors
+ * when the ONNX input is NCHW and should be filled directly as planar RGB.
  */
 class OrtQnnModel(context: Context, modelPath: String, private val tag: String) : InferenceModel {
     private val env = OrtEnvironment.getEnvironment()
@@ -30,12 +30,11 @@ class OrtQnnModel(context: Context, modelPath: String, private val tag: String) 
     private val inputName: String
     private val outputNames: List<String>
     private val inputShape: LongArray
-    private val nhwcInput: Boolean
-    private val nchw: FloatArray
     private val outputs: List<FloatArray>
 
     override val accelerator = "NPU"
     override val inputDims: IntArray
+    override val inputUsesNchw: Boolean
     override val outputDims: List<IntArray>
     override val outputElementCounts: IntArray
 
@@ -60,14 +59,14 @@ class OrtQnnModel(context: Context, modelPath: String, private val tag: String) 
             inputName = session.inputNames.first()
             inputShape = (session.inputInfo.getValue(inputName).info as TensorInfo).shape
             // Channel-last QNN exports take [1, H, W, 3] directly (no CPU transpose); legacy exports are NCHW
-            nhwcInput = inputShape.size == 4 && inputShape[3] == 3L && inputShape[1] != 3L
-            require(inputShape.size == 4 && (nhwcInput || inputShape[1] == 3L)) {
+            val inputIsNhwc = inputShape.size == 4 && inputShape[3] == 3L && inputShape[1] != 3L
+            require(inputShape.size == 4 && (inputIsNhwc || inputShape[1] == 3L)) {
                 "Expected a [1, 3, H, W] or [1, H, W, 3] input, got ${inputShape.toList()} for '$inputName'"
             }
-            val height = (if (nhwcInput) inputShape[1] else inputShape[2]).toInt()
-            val width = (if (nhwcInput) inputShape[2] else inputShape[3]).toInt()
+            val height = (if (inputIsNhwc) inputShape[1] else inputShape[2]).toInt()
+            val width = (if (inputIsNhwc) inputShape[2] else inputShape[3]).toInt()
             inputDims = intArrayOf(1, height, width, 3)
-            nchw = if (nhwcInput) FloatArray(0) else FloatArray(3 * height * width)
+            inputUsesNchw = !inputIsNhwc
 
             // One ordered name list drives both shape discovery and result reads, so they can never desynchronize
             outputNames = session.outputNames.toList()
@@ -104,15 +103,9 @@ class OrtQnnModel(context: Context, modelPath: String, private val tag: String) 
         throw IllegalArgumentException("QNN model not found at '$modelPath' (filesystem or assets)")
     }
 
-    /** Run inference on NHWC interleaved-RGB floats, returning each output as a flat float array. */
+    /** Run inference on floats in the ONNX input layout, returning each output as a flat float array. */
     override fun run(input: FloatArray): List<FloatArray> {
-        val floats = if (nhwcInput) {
-            input // channel-last graph: feed the predictors' NHWC buffer directly
-        } else {
-            ImageUtils.hwcToChw(input, nchw) // transpose into the preallocated planar CHW buffer
-            nchw
-        }
-        OnnxTensor.createTensor(env, FloatBuffer.wrap(floats), inputShape).use { tensor ->
+        OnnxTensor.createTensor(env, FloatBuffer.wrap(input), inputShape).use { tensor ->
             session.run(mapOf(inputName to tensor)).use { results ->
                 return outputNames.mapIndexed { i, name ->
                     readOutput(results.get(name).get() as OnnxTensor, outputs[i])

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -100,7 +100,12 @@ class PoseEstimator(
             isFrontCamera = isFrontCamera,
             rotationDegrees = cameraRotationDegrees
         )
-        ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
+        ImageUtils.copyRgbBitmapToFloatArray(
+            inputBitmap,
+            floatInput,
+            intValues,
+            channelsFirst = rtModel.inputUsesNchw
+        )
 
         val preEnd = System.nanoTime()
         val flat = rtModel.run(floatInput)[0]

--- a/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Predictor.kt
@@ -14,10 +14,10 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 /**
- * Runtime-agnostic inference model behind the predictors: NHWC interleaved-RGB float32 in, flat float32 outputs out.
+ * Runtime-agnostic inference model behind the predictors: normalized RGB float32 in, flat float32 outputs out.
  * Implemented by [LiteRtModel] (TFLite on LiteRT, GPU→CPU ladder) and [OrtQnnModel] (QNN context-binary ONNX on the
- * Snapdragon NPU). Implementations that run an NCHW model (e.g. `format=litert` litert-torch exports) transpose the
- * interleaved input internally and still report [inputDims] in NHWC convention, so predictors stay layout-agnostic.
+ * Snapdragon NPU). [inputDims] is reported in NHWC convention for every backend; [inputUsesNchw] tells predictors
+ * whether to write the float input as planar CHW instead of interleaved HWC.
  */
 interface InferenceModel {
     /** Accelerator in use: "NPU", "GPU" or "CPU". */
@@ -26,13 +26,16 @@ interface InferenceModel {
     /** Input tensor dimensions in NHWC convention, e.g. [1, 640, 640, 3]. */
     val inputDims: IntArray
 
+    /** True when [run] expects planar CHW input; false for interleaved HWC input. */
+    val inputUsesNchw: Boolean
+
     /** Float element count of each output buffer, in order. */
     val outputElementCounts: IntArray
 
     /** Output tensor dimensions, in order (e.g. [[1, 84, 8400]] for detect). */
     val outputDims: List<IntArray>
 
-    /** Run inference on NHWC interleaved-RGB floats, returning each output as a flat float array. */
+    /** Run inference on floats in the layout advertised by [inputUsesNchw], returning flat float outputs. */
     fun run(input: FloatArray): List<FloatArray>
 
     fun close()

--- a/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/Segmenter.kt
@@ -124,7 +124,12 @@ class Segmenter(
             isFrontCamera = isFrontCamera,
             rotationDegrees = cameraRotationDegrees
         )
-        ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
+        ImageUtils.copyRgbBitmapToFloatArray(
+            inputBitmap,
+            floatInput,
+            intValues,
+            channelsFirst = rtModel.inputUsesNchw
+        )
 
         numClasses = out0NumFeatures - boxFeatureLength - maskConfidenceLength
 

--- a/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/SemanticSegmenter.kt
@@ -65,7 +65,12 @@ class SemanticSegmenter(
             isFrontCamera = isFrontCamera,
             rotationDegrees = cameraRotationDegrees
         )
-        ImageUtils.copyRgbBitmapToFloatArray(inputBitmap, floatInput, intValues)
+        ImageUtils.copyRgbBitmapToFloatArray(
+            inputBitmap,
+            floatInput,
+            intValues,
+            channelsFirst = rtModel.inputUsesNchw
+        )
 
         // Keep the model output flat; postProcessSemantic indexes it directly (no per-frame reshape copy).
         val preEnd = System.nanoTime()

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -32,12 +32,12 @@ Use a simple rule:
 
 ## 📊 Measured Backend Performance
 
-End-to-end `predict()` speeds for the official YOLO26n models on a [Xiaomi 17](https://www.mi.com/) phone powered by the
+End-to-end `predict()` speeds for the official YOLO26n models on a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) phone powered by the
 Qualcomm [Snapdragon 8 Elite Gen 5](https://www.qualcomm.com/smartphones) (SM8850), which pairs
 a Qualcomm Oryon CPU with an Adreno GPU and the Hexagon NPU (HTP architecture v81). Each cell shows the **total time**
 with the preprocess / inference / postprocess split beneath it.
 
-| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> | NPU Hexagon<br><sup>QNN A16W8<br>(ms)</sup>      |
+| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> | NPU Hexagon<br><sup>QNN W8A16<br>(ms)</sup>      |
 | ------------ | -------- | --------------------------- | ------------------------------------- | -------------------------------------------- | ------------------------------------------------ |
 | YOLO26n      | Detect   | 640                         | 53.3<br><sup>3.6 / 47.4 / 2.4</sup>   | 17.2<br><sup>3.6 / 9.1 / 4.5</sup>           | **11.3**<br><sup>3.5 / 5.6 / 2.2</sup>           |
 | YOLO26n-seg  | Segment  | 640                         | 76.0<br><sup>3.6 / 64.7 / 7.7</sup>   | 23.9<br><sup>3.6 / 11.8 / 8.6</sup>          | **21.3**<br><sup>3.5 / 7.9 / 10.0</sup>          |
@@ -49,10 +49,14 @@ with the preprocess / inference / postprocess split beneath it.
 - **Speed** values are the full `predict()` time — preprocessing + inference + postprocessing, excluding annotation
   drawing — as the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg).
   <br>Reproduce with `ENABLE_QNN=1 flutter test integration_test/qnn_benchmark_test.dart -d <device> --dart-define=RUN_BENCH=true` (the example app's QNN runtime is opt-in)
+- Benchmarks were run with the `ultralytics_yolo` Flutter plugin `0.6.8`; official Android LiteRT assets are hosted
+  on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6).
 - **CPU** and **GPU** run the legacy official INT8 TFLite assets (the prior `v0.3.5` default; the current default is
   w8a32 LiteRT — see the migration table below), on LiteRT with `useGpu: false` / `true`. **NPU** runs the
   `*_v81_qnn.onnx` context binaries (INT8 weights, 16-bit activations) from the same release via the ONNX Runtime QNN
   Execution Provider.
+- This mixed CPU/GPU/NPU snapshot is kept for QNN comparison. For the current Android LiteRT CPU/GPU numbers after
+  the latest preprocessing and segment/semantic postprocess cleanup, use the migration and LiteRT tables below.
 - <sup>1</sup> Semantic QNN uses the in-graph ArgMax class-map exports (ultralytics#24790), which replaced erratic
   123-1065 ms logits decoding with a stable ~49 ms; the GPU remains slightly faster for semantic at 1024px. The
   official `v0.3.5` QNN release assets ship in this channel-last class-map format, exported with ultralytics
@@ -60,15 +64,17 @@ with the preprocess / inference / postprocess split beneath it.
 - **These are single-image burst latencies**, not sustained camera frame times: one photo through `predict()` on a
   thermally rested device. Real-time camera operation runs higher — full-sensor frames are letterboxed to the model
   input every frame and the silicon thermally settles under load (on an iPhone 17 Pro, YOLO26n detect measures
-  ~3.8 ms burst but ~16 ms/frame sustained in the live camera). Watch the in-app pre/inference/post HUD line for
-  your device's steady-state numbers, and benchmark your exact models on your target hardware.
+  ~3.8 ms burst but ~16 ms/frame sustained in the live camera). On Android, portrait live-camera preprocessing still
+  pays for CameraX frame rotation/letterbox every frame, so the in-app `pre` HUD can remain several milliseconds
+  higher than the single-image rows even after the RGB packing cleanup. Watch the in-app pre/inference/post HUD line
+  for your device's steady-state numbers, and benchmark your exact models on your target hardware.
 
 ### Format migration: legacy INT8 TFLite → w8a32 LiteRT
 
 The official Android assets moved from the legacy onnx2tf **INT8 TFLite** format (NHWC, `v0.3.5`) to **w8a32 LiteRT**
 (int8 weights + FP32 activations, NCHW, `v0.6.6`) — the smallest GPU-compatible litert format, which needs no
 calibration data. The CPU/GPU columns above are the legacy INT8 baseline; the table below compares the four litert
-quantization formats against it on the same Xiaomi 17.
+quantization formats against it on the same [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/).
 
 Same-device yolo26n detect, Adreno GPU, measured in one sustained sweep — so **inference** (the format-dependent stage)
 is the comparable metric; preprocessing reflects the warmed-up thermal state of the back-to-back run:
@@ -88,26 +94,30 @@ is the comparable metric; preprocessing reflects the warmed-up thermal state of 
   download; **w8a16 fails to compile on the GPU delegate** and runs ~40× slower on CPU, so it is not used.
 
 Per-task before/after on the Adreno GPU — the legacy onnx2tf **INT8 TFLite** assets vs the new **w8a32 LiteRT** assets,
-both measured in the same run on the Xiaomi 17 at the shipped Android `imgsz` (224 classify, 640 others). Each cell is
-the **total** with the preprocess / inference / postprocess split beneath it:
+both measured in the same run on the [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) at the shipped Android
+`imgsz` (224 classify, 640 others). Each cell is the **total** with the preprocess / inference / postprocess split
+beneath it. The runtime was `ultralytics_yolo` `0.6.8`; the `w8a32` assets come from the
+[yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6).
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | Before<br><sup>onnx2tf INT8 TFLite<br>(ms)</sup> | After<br><sup>w8a32 LiteRT<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | ------------------------------------------------ | ---------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 18.8<br><sup>7.8 / 8.3 / 2.7</sup>               | **17.4**<br><sup>6.2 / 8.6 / 2.6</sup>   |
-| YOLO26n-seg  | Segment  | 640                         | 45.2<br><sup>7.8 / 22.9 / 14.4</sup>             | **43.4**<br><sup>7.7 / 21.9 / 13.7</sup> |
-| YOLO26n-sem  | Semantic | 640                         | **50.5**<br><sup>6.5 / 27.7 / 16.3</sup>         | 59.4<br><sup>7.5 / 34.4 / 17.5</sup>     |
-| YOLO26n-cls  | Classify | 224                         | 5.9<br><sup>1.5 / 2.0 / 2.5</sup>                | **4.9**<br><sup>1.7 / 2.0 / 1.3</sup>    |
-| YOLO26n-pose | Pose     | 640                         | **22.5**<br><sup>7.8 / 9.8 / 4.8</sup>           | 24.0<br><sup>9.1 / 10.4 / 4.5</sup>      |
-| YOLO26n-obb  | OBB      | 640                         | 19.0<br><sup>7.7 / 8.4 / 2.9</sup>               | **18.4**<br><sup>7.7 / 8.6 / 2.0</sup>   |
+| YOLO26n      | Detect   | 640                         | 14.0<br><sup>1.8 / 8.1 / 4.2</sup>               | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>   |
+| YOLO26n-seg  | Segment  | 640                         | 30.1<br><sup>1.9 / 20.3 / 8.0</sup>              | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>  |
+| YOLO26n-sem  | Semantic | 640                         | **26.4**<br><sup>1.9 / 16.4 / 8.1</sup>          | 32.9<br><sup>1.8 / 23.0 / 8.2</sup>      |
+| YOLO26n-cls  | Classify | 224                         | 3.5<br><sup>0.9 / 2.2 / 0.4</sup>                | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>    |
+| YOLO26n-pose | Pose     | 640                         | 17.4<br><sup>2.4 / 9.9 / 5.1</sup>               | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>   |
+| YOLO26n-obb  | OBB      | 640                         | 13.9<br><sup>3.0 / 8.3 / 2.7</sup>               | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>   |
 
-w8a32 matches or beats the legacy onnx2tf INT8 format on four of six tasks; **semantic is the clear regression**
-(+9 ms, from the NCHW FP32-activation inference and host-side argmax) and pose is ~1.5 ms slower. The legacy onnx2tf
-models run unchanged on LiteRT 2.x alongside the new NCHW exports, confirming the runtime's layout-adaptive path.
+w8a32 matches or beats the legacy onnx2tf INT8 format on five of six tasks in total latency. **Semantic remains the
+format regression** because the w8a32 NCHW logits cost more inference time than the legacy NHWC logits, even after
+preprocessing cleanup. The legacy onnx2tf models run unchanged on LiteRT 2.x alongside the new NCHW exports,
+confirming the runtime's layout-adaptive path.
 
 ## 🔭 Optimization Findings and Future Exploration
 
-The table above reflects a device-validated optimization pass (Snapdragon 8 Elite Gen 5, June 2026). What was tried,
-what worked, and what's left on the table:
+The migration table above reflects the current Android LiteRT optimization pass on the Snapdragon 8 Elite Gen 5,
+including the segment/semantic postprocess work from #549 and #550. What was tried, what worked, and what's left on
+the table:
 
 **Shipped (in the table):**
 
@@ -133,9 +143,22 @@ what worked, and what's left on the table:
 - **High-resolution segment overlays** (#549): the visible combined mask now scales logits to model-input resolution
   before thresholding, matching the iOS SDK's sharp segment overlay path instead of upscaling a 160x160 RGBA mask.
   A naive Kotlin bilinear paint measured **15.5 ms postprocess** and was rejected; caching per-column interpolation
-  reduced the Xiaomi 17 GPU path to **7.6-8.6 ms postprocess** for `yolo26n-seg`, trading ~1.5-2.5 ms for
-  model-resolution masks while keeping the cache-local decode/mask-gen wins above. Raw mask payloads remain at the
-  existing cropped proto resolution.
+  reduced the [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) GPU path to **6.7-8.0 ms postprocess** for
+  `yolo26n-seg`, trading a small amount of time for model-resolution masks while keeping the cache-local
+  decode/mask-gen wins above. Raw mask payloads remain at the existing cropped proto resolution.
+- **Preprocessing cleanup**: the Android path writes NCHW inputs directly for NCHW LiteRT/QNN models, eliminating the
+  extra HWC→CHW float transpose, and clears only real letterbox padding instead of repainting the full target bitmap
+  every frame. On the [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) w8a32 GPU sweep, 640px preprocessing is
+  now ~1.8-1.9 ms across detect/segment/semantic/pose and ~2.9 ms for OBB, down from the old 6-9 ms range for
+  single-image `predict()` benchmarks. The live camera HUD can still show ~5-10 ms `pre` in portrait because that path
+  also rotates and letterboxes each CameraX frame before packing RGB.
+- **Rejected live-camera preprocessing prototypes**: fusing CameraX RGBA `ImageProxy` → rotated/letterboxed CHW floats
+  in Kotlin was slower than the current Bitmap/Canvas path on the [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/)
+  `yolo26n-seg` live HUD. Direct `ByteBuffer` bilinear sampling measured **55.6 ms pre**, direct nearest-neighbor
+  measured **61.1 ms pre**, and copying the RGBA plane into a reusable `ByteArray` before nearest-neighbor sampling
+  measured **10.5 ms pre**. The restored Bitmap/Canvas path measured **~7.4 ms pre** in the same validation session.
+  A 320x240 CameraX analysis stream spot-check was also neutral (**7.1 ms pre**) while reducing input detail before
+  upscaling to the 640px model input, so lower camera resolution is not a default speed fix.
 - **Postprocess overhead cleanup** (#549): classifier top-5 now uses fixed-size linear insertion instead of sorting
   every score; semantic keeps dense class maps as `IntArray` until Flutter serialization; segment NMS buckets
   detections once by class instead of filtering the full candidate list per class; native detect NMS stops once
@@ -151,7 +174,7 @@ what worked, and what's left on the table:
   corner for burst and sustained; the default stays `burst`.
 - `offload_graph_io_quantization=0`: no measurable effect on normal-sized outputs.
 - **Naive A8W8 quantization**: 33% faster inference but zero detections — a shared uint8 scale on the concatenated
-  output destroys scores. A16W8 stays the export default.
+  output destroys scores. W8A16 stays the export default.
 - **fp16 GPU variants**: identical inference time to INT8 on the LiteRT GPU accelerator (it computes in fp16
   internally either way) — no reason to ship larger fp16 assets.
 - **In-graph ArgMax for semantic TFLite**: the GPU delegate cannot compile `ARG_MAX` with int64 indices (what

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "2032fe44e6f93113497df9ffe8c5fab9e4ee1c9d",
-        "version" : "8.9.10"
+        "revision" : "7bb1b4b01f5f592e13c039f45b85cf8f89057dfe",
+        "version" : "8.9.11"
       }
     }
   ],

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "2032fe44e6f93113497df9ffe8c5fab9e4ee1c9d",
-        "version" : "8.9.10"
+        "revision" : "7bb1b4b01f5f592e13c039f45b85cf8f89057dfe",
+        "version" : "8.9.11"
       }
     }
   ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.7+15
+version: 0.6.8+16
 
 environment:
   sdk: ^3.8.1

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ultralytics_yolo'
-  s.version          = '0.6.0'
+  s.version          = '0.6.8'
   s.summary          = 'Flutter plugin for YOLO (You Only Look Once) models'
   s.description      = <<-DESC
 Flutter plugin for YOLO (You Only Look Once) models, supporting object detection, segmentation, classification, pose estimation and oriented bounding boxes (OBB) on both Android and iOS.
@@ -19,7 +19,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # "no rule to process file ... net.daringfireball.markdown" warning Xcode emits when README.md is swept in.
   s.source_files = 'ultralytics_yolo/Sources/ultralytics_yolo/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.10', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.11', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/ultralytics_yolo/Package.swift
+++ b/ios/ultralytics_yolo/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   ],
   dependencies: [
     // Shared YOLO inference core, the single source of truth for iOS (https://github.com/ultralytics/yolo-ios-app).
-    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.10', '< 9.0'` range in the podspec.
-    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.10"..<"9.0.0")
+    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.11', '< 9.0'` range in the podspec.
+    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.11"..<"9.0.0")
   ],
   targets: [
     .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.7
+version: 0.6.8
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary
- write NCHW LiteRT/QNN inputs directly during RGB packing and remove the extra HWC-to-CHW transpose
- clear only actual letterbox padding during Android preprocessing
- bump the Flutter package to 0.6.8 and update the iOS UltralyticsYOLO dependency to 8.9.11
- refresh the Flutter performance notes with the current Xiaomi 17 benchmark rows and source links

## Validation
- flutter pub get
- flutter pub get (example)
- pod ipc spec ios/ultralytics_yolo.podspec
- swift package dump-package --package-path ios/ultralytics_yolo
- flutter test
- flutter analyze
- dart pub publish --dry-run (dirty-git warning only)
- git diff --check

## Notes
- untracked local benchmark/audit helper files are intentionally excluded from this PR

## Related
- ultralytics/ultralytics#25015

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Ultralytics YOLO Flutter plugin `0.6.8` improves Android preprocessing speed for NCHW LiteRT/QNN models, refreshes performance docs, and updates iOS dependencies 🚀

### 📊 Key Changes
- ⚡ **Faster Android input preprocessing**: Predictors now write planar CHW input directly when a model expects NCHW, avoiding an extra HWC-to-CHW transpose.
- 🧠 **Runtime layout awareness**: `InferenceModel` now exposes `inputUsesNchw`, letting all tasks—detect, segment, pose, OBB, classify, and semantic segment—prepare input in the correct layout.
- 🎨 **More efficient letterbox clearing**: Android preprocessing now clears only actual letterbox padding instead of repainting the full target bitmap black.
- 📈 **Updated performance documentation**: Benchmark tables were refreshed with current Xiaomi 17 measurements, including clearer notes on LiteRT, QNN, and live camera preprocessing costs.
- 🍎 **iOS dependency bump**: Requires `UltralyticsYOLO >= 8.9.11` for both CocoaPods and Swift Package Manager.
- 📦 **Version updates**: Plugin and example app versions were bumped to `0.6.8`.

### 🎯 Purpose & Impact
- 🚀 **Lower single-image latency on Android**: Removing unnecessary layout transposes and full-frame clearing can significantly reduce preprocessing time, especially for YOLO26 LiteRT/QNN models.
- 🔋 **Better efficiency on mobile devices**: Less CPU-side preprocessing work helps improve responsiveness and may reduce overhead during repeated predictions.
- 📱 **More accurate user expectations**: Documentation now clearly explains that live camera performance can still be slower than single-image benchmarks due to per-frame CameraX rotation and letterboxing.
- 🔄 **Improved backend compatibility**: The plugin now handles NHWC and NCHW model layouts more cleanly across LiteRT, TFLite, and QNN backends.
- 🛠️ **Smoother iOS integration**: Updating to `UltralyticsYOLO 8.9.11` keeps the Flutter plugin aligned with the latest iOS YOLO inference core.