### PR TITLE
Filter Play Store bundled model assets

### DIFF
--- a/scripts/build_play_store_assets.sh
+++ b/scripts/build_play_store_assets.sh
@@ -5,6 +5,7 @@
 # Build the local Google Play Console upload assets for the example Android app.
 
 set -euo pipefail
+shopt -s dotglob
 
 usage() {
   echo "Usage: $0 [--notes path/to/whats-new.txt] | --verify-aab path/to/app.aab" >&2
@@ -81,6 +82,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 STORE_DIR="$REPO_ROOT/play-store-assets"
 EXAMPLE_DIR="$REPO_ROOT/example"
+MODEL_DIR="$EXAMPLE_DIR/assets/models"
+TMP_STORE_DIR=""
+MODEL_STASH_DIR=""
+
+cleanup() {
+  local path
+  if [ -n "$MODEL_STASH_DIR" ] && [ -d "$MODEL_STASH_DIR" ]; then
+    for path in "$MODEL_STASH_DIR"/*; do
+      [ -e "$path" ] || continue
+      mv -f "$path" "$MODEL_DIR/"
+    done
+    rmdir "$MODEL_STASH_DIR"
+  fi
+  if [ -n "$TMP_STORE_DIR" ]; then
+    rm -rf "$TMP_STORE_DIR"
+  fi
+}
+trap cleanup EXIT
 
 pubspec_version() {
   awk -F': *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' "$1"
@@ -168,13 +187,31 @@ extract_changelog_notes() {
 
 echo "build_play_store_assets: building ultralytics_yolo $VERSION_NAME+$VERSION_CODE"
 
+mkdir -p "$STORE_DIR"
+mkdir -p "$MODEL_DIR"
+MODEL_STASH_DIR="$(mktemp -d "$STORE_DIR/.tmp-model-assets.XXXXXX")"
+for path in "$MODEL_DIR"/*; do
+  [ -e "$path" ] || continue
+  [ -f "$path" ] || continue
+  case "$(basename "$path")" in
+    .gitkeep | \
+      yolo26n_w8a32.tflite | \
+      yolo26n-seg_w8a32.tflite | \
+      yolo26n-sem_w8a32.tflite | \
+      yolo26n-cls_w8a32.tflite | \
+      yolo26n-pose_w8a32.tflite | \
+      yolo26n-obb_w8a32.tflite) ;;
+    *)
+      mv "$path" "$MODEL_STASH_DIR/"
+      ;;
+  esac
+done
+
 (cd "$REPO_ROOT" && flutter pub get)
 (cd "$EXAMPLE_DIR" && flutter pub get)
 (cd "$EXAMPLE_DIR" && flutter build appbundle --release)
 
-mkdir -p "$STORE_DIR"
 TMP_STORE_DIR="$(mktemp -d "$STORE_DIR/.tmp-play-store-assets.XXXXXX")"
-trap 'rm -rf "$TMP_STORE_DIR"' EXIT
 
 AAB_SOURCE="$EXAMPLE_DIR/build/app/outputs/bundle/release/app-release.aab"
 AAB_DEST="$STORE_DIR/ultralytics-yolo-$VERSION_NAME-build$VERSION_CODE.aab"


### PR DESCRIPTION
## Summary
- stage non-release files out of `example/assets/models` while building Play Store upload assets
- restore local model files after the build so benchmark/custom assets are preserved
- keep the release AAB limited to `.gitkeep` plus the six official Android `yolo26n*_w8a32.tflite` bundled models

## Tests
- `bash -n scripts/build_play_store_assets.sh`
- `scripts/build_play_store_assets.sh`
- `unzip -Z1 play-store-assets/ultralytics-yolo-0.6.8-build16.aab | rg 'assets/flutter_assets/assets/models|\\.mlpackage|legacyint8|\\.tflite|\\.zip$'`\n- `find example/assets/models -maxdepth 1 -type f -exec basename {} \\; | sort`\n- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Play Store asset build script to package only the approved YOLO26 model assets and safely restore any other local model files afterward 🚀

### 📊 Key Changes
- Enables `dotglob` so hidden files like `.gitkeep` are included during file handling 🗂️
- Adds model asset filtering for the example app’s `assets/models` directory
- Keeps only approved YOLO26 TFLite models during the Android App Bundle build:
  - `yolo26n_w8a32.tflite`
  - `yolo26n-seg_w8a32.tflite`
  - `yolo26n-sem_w8a32.tflite`
  - `yolo26n-cls_w8a32.tflite`
  - `yolo26n-pose_w8a32.tflite`
  - `yolo26n-obb_w8a32.tflite`
- Temporarily stashes any other local model files before building, then restores them automatically ✅
- Improves cleanup handling with a shared `cleanup` function and `trap` to remove temporary directories safely

### 🎯 Purpose & Impact
- Reduces the risk of accidentally shipping extra or experimental model files in Play Store builds 📦
- Helps ensure Google Play upload assets include the intended YOLO26 models only
- Preserves developers’ local model files, avoiding data loss during the build process 🛡️
- Makes the release build process more reliable, cleaner, and easier to maintain for the Flutter example app ✨