### PR TITLE
Support custom pose keypoint counts on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.9
+
+- **Fix**: Android pose inference now derives the keypoint count from the model output feature width, allowing custom
+  pose models such as 21-keypoint hand landmarks to return all keypoints instead of requiring COCO's 17-keypoint shape
+  (#555).
+
 ## 0.6.8
 
 - **Performance**: Speed up Android single-image preprocessing for NCHW LiteRT/QNN models by writing planar CHW input

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -24,22 +24,22 @@ class PoseEstimator(
     }
 
     companion object {
-        // xywh(4) + conf(1) + keypoints(17*3=51) = 56
-        private const val OUTPUT_FEATURES = 56
-        private const val KEYPOINTS_COUNT = 17
+        private const val BOX_CONF_FEATURES = 5
+        private const val MIN_KEYPOINT_FEATURES = 3
     }
 
     // Reusable float input for the CompiledModel input buffer.
     private lateinit var floatInput: FloatArray
     private lateinit var inputBitmap: Bitmap
     private lateinit var intValues: IntArray
-    
+
     // Reuse output arrays to reduce allocations
     private var outDim2 = 0
-    
+
     // Output dimensions
     private var batchSize = 0
     private var numAnchors = 0
+    private var keypointCount = 0
     private var isEndToEnd = false
     private lateinit var outputLayout: OutputLayout
 
@@ -61,13 +61,18 @@ class PoseEstimator(
         modelInputSize = Pair(inWidth, inHeight)
 
         val outputShape = rtModel.outputDims.getOrNull(0) ?: IntArray(0)
-        batchSize = if (outputShape.isNotEmpty()) outputShape[0] else 1
+        require(outputShape.size >= 3) {
+            "Unexpected pose output shape. Expected [batch, features, anchors] or [batch, anchors, features], Actual=${outputShape.contentToString()}"
+        }
+
+        batchSize = outputShape[0]
         isEndToEnd = outputShape[2] < outputShape[1] && outputShape[2] >= 6
         outputLayout = when {
-            outputShape[1] == OUTPUT_FEATURES -> OutputLayout.FEATURES_FIRST
-            outputShape[2] == OUTPUT_FEATURES || isEndToEnd -> OutputLayout.ANCHORS_FIRST
+            isEndToEnd -> OutputLayout.ANCHORS_FIRST
+            isPoseFeatureCount(outputShape[1]) -> OutputLayout.FEATURES_FIRST
+            isPoseFeatureCount(outputShape[2]) -> OutputLayout.ANCHORS_FIRST
             else -> throw IllegalArgumentException(
-                "Unexpected output feature size. Expected $OUTPUT_FEATURES or end-to-end rows, Actual=${outputShape.contentToString()}"
+                "Unexpected pose output feature size. Expected 5 + keypoints * 3 features or end-to-end rows, Actual=${outputShape.contentToString()}"
             )
         }
 
@@ -83,6 +88,9 @@ class PoseEstimator(
             }
         }
 
+        if (!isEndToEnd) {
+            keypointCount = keypointCountFromFeatureCount(outFeatures)
+        }
         outDim2 = outputShape[2]
 
         floatInput = FloatArray(inWidth * inHeight * 3)
@@ -122,7 +130,7 @@ class PoseEstimator(
 
         // Apply numItemsThreshold limit
         val limitedDetections = rawDetections.take(numItemsThreshold)
-        
+
         val boxes = limitedDetections.map { it.box }
         val keypointsList = limitedDetections.map { it.keypoints }
 
@@ -181,10 +189,10 @@ class PoseEstimator(
 
             val kpArray = mutableListOf<Pair<Float, Float>>()
             val kpConfArray = mutableListOf<Float>()
-            for (k in 0 until KEYPOINTS_COUNT) {
-                val rawKx = featureValue(flat, 5 + k * 3, j)
-                val rawKy = featureValue(flat, 5 + k * 3 + 1, j)
-                val kpC   = featureValue(flat, 5 + k * 3 + 2, j)
+            for (k in 0 until keypointCount) {
+                val rawKx = featureValue(flat, BOX_CONF_FEATURES + k * 3, j)
+                val rawKy = featureValue(flat, BOX_CONF_FEATURES + k * 3 + 1, j)
+                val kpC = featureValue(flat, BOX_CONF_FEATURES + k * 3 + 2, j)
 
                 val (finalKx, finalKy) = inputPointFromOutputPoint(
                     rawKx,
@@ -202,13 +210,13 @@ class PoseEstimator(
                 (fx / origWidth) to (fy / origHeight)
             }
             val boxObj = Box(0, labelName(0), conf, rectF, normBox)
-            
+
             val keypoints = Keypoints(
                 xyn = xynList,
                 xy = kpArray,
                 conf = kpConfArray
             )
-            
+
             detections.add(
                 PoseDetection(
                     box = boxObj,
@@ -295,6 +303,17 @@ class PoseEstimator(
         }
     }
 
+    private fun isPoseFeatureCount(featureCount: Int): Boolean {
+        return featureCount >= BOX_CONF_FEATURES + MIN_KEYPOINT_FEATURES &&
+            (featureCount - BOX_CONF_FEATURES) % 3 == 0
+    }
+
+    private fun keypointCountFromFeatureCount(featureCount: Int): Int {
+        require(isPoseFeatureCount(featureCount)) {
+            "Unexpected pose output feature size. Expected 5 + keypoints * 3, Actual=$featureCount"
+        }
+        return (featureCount - BOX_CONF_FEATURES) / 3
+    }
 
     private fun nmsPoseDetections(
         detections: List<PoseDetection>,
@@ -302,11 +321,11 @@ class PoseEstimator(
     ): List<PoseDetection> {
         val confidenceThreshold = 0.25f  // Hardcoded second-pass threshold
         val filteredDetections = detections.filter { it.box.conf >= confidenceThreshold }
-        
+
         if (filteredDetections.size <= 1) {
             return filteredDetections
         }
-        
+
         val sorted = filteredDetections.sortedByDescending { it.box.conf }
         val picked = mutableListOf<PoseDetection>()
         val used = BooleanArray(sorted.size)
@@ -340,7 +359,6 @@ class PoseEstimator(
         return if (unionArea <= 0f) 0f else (interArea / unionArea)
     }
 
-
     override fun setConfidenceThreshold(conf: Double) {
         confidenceThreshold = conf.toFloat()
         super.setConfidenceThreshold(conf)
@@ -350,7 +368,7 @@ class PoseEstimator(
         iouThreshold = iou.toFloat()
         super.setIouThreshold(iou)
     }
-    
+
     override fun setNumItemsThreshold(n: Int) {
         numItemsThreshold = n
         super.setNumItemsThreshold(n)
@@ -368,5 +386,4 @@ class PoseEstimator(
         val box: Box,
         val keypoints: Keypoints
     )
-    
 }

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -26,6 +26,7 @@ class PoseEstimator(
     companion object {
         private const val BOX_CONF_FEATURES = 5
         private const val MIN_KEYPOINT_FEATURES = 3
+        private const val END_TO_END_MAX_ROWS = 1000
     }
 
     // Reusable float input for the CompiledModel input buffer.
@@ -39,6 +40,7 @@ class PoseEstimator(
     // Output dimensions
     private var batchSize = 0
     private var numAnchors = 0
+    private var keypointStart = BOX_CONF_FEATURES
     private var keypointCount = 0
     private var isEndToEnd = false
     private lateinit var outputLayout: OutputLayout
@@ -66,11 +68,16 @@ class PoseEstimator(
         }
 
         batchSize = outputShape[0]
-        isEndToEnd = outputShape[2] < outputShape[1] && outputShape[2] >= 6
+        val anchorsFirstPose = isPoseFeatureCount(outputShape[2]) && outputShape[1] > END_TO_END_MAX_ROWS
+        val featuresFirstPose = isPoseFeatureCount(outputShape[1]) && !anchorsFirstPose
+        isEndToEnd = !featuresFirstPose &&
+            !anchorsFirstPose &&
+            outputShape[1] <= END_TO_END_MAX_ROWS &&
+            outputShape[2] < outputShape[1] &&
+            outputShape[2] >= 6
         outputLayout = when {
-            isEndToEnd -> OutputLayout.ANCHORS_FIRST
-            isPoseFeatureCount(outputShape[1]) -> OutputLayout.FEATURES_FIRST
-            isPoseFeatureCount(outputShape[2]) -> OutputLayout.ANCHORS_FIRST
+            featuresFirstPose -> OutputLayout.FEATURES_FIRST
+            isEndToEnd || anchorsFirstPose -> OutputLayout.ANCHORS_FIRST
             else -> throw IllegalArgumentException(
                 "Unexpected pose output feature size. Expected 5 + keypoints * 3 features or end-to-end rows, Actual=${outputShape.contentToString()}"
             )
@@ -88,9 +95,8 @@ class PoseEstimator(
             }
         }
 
-        if (!isEndToEnd) {
-            keypointCount = keypointCountFromFeatureCount(outFeatures)
-        }
+        keypointStart = if (isEndToEnd && (outFeatures - 6) % 3 == 0) 6 else BOX_CONF_FEATURES
+        keypointCount = keypointCountFromFeatureCount(outFeatures, keypointStart)
         outDim2 = outputShape[2]
 
         floatInput = FloatArray(inWidth * inHeight * 3)
@@ -236,9 +242,6 @@ class PoseEstimator(
         origHeight: Int
     ): List<PoseDetection> {
         val detections = mutableListOf<PoseDetection>()
-        val fieldCount = outDim2
-        val keypointStart = if ((fieldCount - 6) % 3 == 0) 6 else 5
-        val keypointCount = (fieldCount - keypointStart) / 3
 
         for (j in 0 until numAnchors) {
             val conf = featureValue(flat, 4, j)
@@ -308,11 +311,11 @@ class PoseEstimator(
             (featureCount - BOX_CONF_FEATURES) % 3 == 0
     }
 
-    private fun keypointCountFromFeatureCount(featureCount: Int): Int {
-        require(isPoseFeatureCount(featureCount)) {
-            "Unexpected pose output feature size. Expected 5 + keypoints * 3, Actual=$featureCount"
+    private fun keypointCountFromFeatureCount(featureCount: Int, keypointStart: Int = BOX_CONF_FEATURES): Int {
+        require(featureCount >= keypointStart && (featureCount - keypointStart) % 3 == 0) {
+            "Unexpected pose output feature size. Expected keypoint triplets after $keypointStart box fields, Actual=$featureCount"
         }
-        return (featureCount - BOX_CONF_FEATURES) / 3
+        return (featureCount - keypointStart) / 3
     }
 
     private fun nmsPoseDetections(

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -68,13 +68,12 @@ class PoseEstimator(
         }
 
         batchSize = outputShape[0]
+        val featuresFirstPose = isPoseFeatureCount(outputShape[1]) && outputShape[2] > END_TO_END_MAX_ROWS
         val anchorsFirstPose = isPoseFeatureCount(outputShape[2]) && outputShape[1] > END_TO_END_MAX_ROWS
-        val featuresFirstPose = isPoseFeatureCount(outputShape[1]) && !anchorsFirstPose
         isEndToEnd = !featuresFirstPose &&
             !anchorsFirstPose &&
             outputShape[1] <= END_TO_END_MAX_ROWS &&
-            outputShape[2] < outputShape[1] &&
-            outputShape[2] >= 6
+            isEndToEndFeatureCount(outputShape[2])
         outputLayout = when {
             featuresFirstPose -> OutputLayout.FEATURES_FIRST
             isEndToEnd || anchorsFirstPose -> OutputLayout.ANCHORS_FIRST
@@ -309,6 +308,11 @@ class PoseEstimator(
     private fun isPoseFeatureCount(featureCount: Int): Boolean {
         return featureCount >= BOX_CONF_FEATURES + KEYPOINT_FEATURES &&
             (featureCount - BOX_CONF_FEATURES) % KEYPOINT_FEATURES == 0
+    }
+
+    private fun isEndToEndFeatureCount(featureCount: Int): Boolean {
+        return isPoseFeatureCount(featureCount) ||
+            (featureCount >= 6 + KEYPOINT_FEATURES && (featureCount - 6) % KEYPOINT_FEATURES == 0)
     }
 
     private fun keypointCountFromFeatureCount(featureCount: Int, keypointStart: Int = BOX_CONF_FEATURES): Int {

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -312,17 +312,10 @@ class PoseEstimator(
     }
 
     private fun keypointCountFromFeatureCount(featureCount: Int, keypointStart: Int = BOX_CONF_FEATURES): Int {
-<<<<<<< HEAD
-        require(featureCount >= keypointStart && (featureCount - keypointStart) % 3 == 0) {
-            "Unexpected pose output feature size. Expected keypoint triplets after $keypointStart box fields, Actual=$featureCount"
-        }
-        return (featureCount - keypointStart) / 3
-=======
         require(featureCount >= keypointStart && (featureCount - keypointStart) % KEYPOINT_FEATURES == 0) {
             "Unexpected pose output feature size. Expected keypoint triplets after $keypointStart box fields, Actual=$featureCount"
         }
         return (featureCount - keypointStart) / KEYPOINT_FEATURES
->>>>>>> c92caff (Prepare custom pose keypoint release)
     }
 
     private fun nmsPoseDetections(

--- a/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/PoseEstimator.kt
@@ -24,9 +24,9 @@ class PoseEstimator(
     }
 
     companion object {
-        private const val BOX_CONF_FEATURES = 5
-        private const val MIN_KEYPOINT_FEATURES = 3
-        private const val END_TO_END_MAX_ROWS = 1000
+        private const val BOX_CONF_FEATURES = 5 // Normal pose prefix: box x/y/w/h plus confidence.
+        private const val KEYPOINT_FEATURES = 3 // One keypoint triplet: x, y, and confidence.
+        private const val END_TO_END_MAX_ROWS = 300 // Ultralytics default max_det for capped end-to-end outputs.
     }
 
     // Reusable float input for the CompiledModel input buffer.
@@ -307,15 +307,22 @@ class PoseEstimator(
     }
 
     private fun isPoseFeatureCount(featureCount: Int): Boolean {
-        return featureCount >= BOX_CONF_FEATURES + MIN_KEYPOINT_FEATURES &&
-            (featureCount - BOX_CONF_FEATURES) % 3 == 0
+        return featureCount >= BOX_CONF_FEATURES + KEYPOINT_FEATURES &&
+            (featureCount - BOX_CONF_FEATURES) % KEYPOINT_FEATURES == 0
     }
 
     private fun keypointCountFromFeatureCount(featureCount: Int, keypointStart: Int = BOX_CONF_FEATURES): Int {
+<<<<<<< HEAD
         require(featureCount >= keypointStart && (featureCount - keypointStart) % 3 == 0) {
             "Unexpected pose output feature size. Expected keypoint triplets after $keypointStart box fields, Actual=$featureCount"
         }
         return (featureCount - keypointStart) / 3
+=======
+        require(featureCount >= keypointStart && (featureCount - keypointStart) % KEYPOINT_FEATURES == 0) {
+            "Unexpected pose output feature size. Expected keypoint triplets after $keypointStart box fields, Actual=$featureCount"
+        }
+        return (featureCount - keypointStart) / KEYPOINT_FEATURES
+>>>>>>> c92caff (Prepare custom pose keypoint release)
     }
 
     private fun nmsPoseDetections(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.8+16
+version: 0.6.9+17
 
 environment:
   sdk: ^3.8.1

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ultralytics_yolo'
-  s.version          = '0.6.8'
+  s.version          = '0.6.9'
   s.summary          = 'Flutter plugin for YOLO (You Only Look Once) models'
   s.description      = <<-DESC
 Flutter plugin for YOLO (You Only Look Once) models, supporting object detection, segmentation, classification, pose estimation and oriented bounding boxes (OBB) on both Android and iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.8
+version: 0.6.9
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary
- infer Android pose keypoint count from output features instead of requiring 56 channels
- preserve capped-row end-to-end pose handling while parsing anchor-grid pose outputs dynamically
- bump package surfaces to 0.6.9 for the Android custom-pose fix

Fixes #555

## Testing
- dart format .
- git diff --check
- dart analyze --fatal-infos
- flutter test
- dart pub publish --dry-run
- (cd example && flutter build apk --debug)
- fresh cold Codex review: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR releases `ultralytics_yolo` 0.6.9 with improved Android pose inference support for custom keypoint models 🧍✨

### 📊 Key Changes
- Fixed Android pose estimation to dynamically calculate the number of keypoints from the model output shape instead of assuming 17 COCO keypoints.
- Added support for custom pose models, such as 21-keypoint hand landmark models.
- Improved output shape validation with clearer error messages for unsupported pose output formats.
- Updated pose output layout detection for both features-first and anchors-first model outputs.
- Bumped package versions from `0.6.8` to `0.6.9` across Flutter, iOS podspec, example app, and changelog.

### 🎯 Purpose & Impact
- Enables Android apps to correctly return all keypoints from custom pose models, not just standard COCO human pose outputs 🎯
- Improves flexibility for developers building hand tracking, custom landmark detection, and other pose-based applications.
- Reduces integration issues by better handling different valid YOLO pose output shapes.
- Provides a more reliable cross-platform Flutter plugin experience for YOLO pose estimation users 🚀