### PR TITLE
Restrict release workflow to the main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/yolo-flutter-app' && github.actor == 'glenn-jocher'
+    if: github.repository == 'ultralytics/yolo-flutter-app' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 🛠️ Summary

Restricts the release workflow to the `main` branch by adding `github.ref == 'refs/heads/main'` to the `check` job condition.

Previously a `workflow_dispatch` run from a feature branch could tag and create a release from a commit that never landed on `main` (the checkout defaults to the dispatched ref). This guard closes that gap while leaving normal push-to-main and main dispatch behavior unchanged. Part of a cross-repo release-workflow hardening pass (see ultralytics/template#91).

## 🧪 Testing

- YAML validated. Push-to-main and main-dispatch paths are unaffected; only non-main dispatch is now skipped.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a branch safeguard to the publish workflow so releases only run from the `main` branch 🚀

### 📊 Key Changes
- Updated `.github/workflows/publish.yml` to add `github.ref == 'refs/heads/main'` to the publish job condition.
- The workflow now requires all three conditions before publishing:
  - Repository is `ultralytics/yolo-flutter-app`
  - Actor is @glenn-jocher
  - Branch is `main` ✅

### 🎯 Purpose & Impact
- Prevents accidental publishing from feature branches or non-main refs 🔒
- Improves release safety and workflow control for the YOLO Flutter app 📦
- Reduces risk of unintended package or artifact publication during development 🛠️