### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,11 @@ jobs:
         run: dart pub publish --dry-run
 
       - name: Upload Coverage Reports to CodeCov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           use_oidc: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: coverage/lcov.info
           disable_search: true
           plugins: noop


### PR DESCRIPTION
## Summary
- make the Codecov coverage upload non-blocking
- keep Flutter test and dry-run failures authoritative

Deleted: nothing. Justification: coverage reporting must remain in place; this replaces fatal upload settings in the existing Codecov step without adding guards or new workflow paths.

## Validation
- YAML parse
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Makes Codecov coverage uploads non-blocking in CI to prevent external reporting issues from failing builds ✅

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step ⚙️
- Changed Codecov `fail_ci_if_error` from `true` to `false` 🛡️
- Keeps coverage upload configured for `coverage/lcov.info` using the Codecov GitHub Action 📈

### 🎯 Purpose & Impact
- Improves CI reliability by ensuring builds do not fail due to Codecov outages, upload errors, or configuration issues 🚀
- Reduces false-negative CI failures for contributors and maintainers 🙌
- Keeps coverage reporting available when Codecov works, while making it non-critical to the release and validation workflow 🔍