### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pubdev
         shell: python


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚙️ Updates the publish workflow to use Ultralytics’ centralized `setup-uv` GitHub Action.

### 📊 Key Changes

- Replaces `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main`.
- Removes the explicit `enable-cache: false` configuration.
- Keeps the existing Python setup and `ultralytics-actions` installation unchanged.

### 🎯 Purpose & Impact

- ✅ Standardizes UV environment setup across Ultralytics repositories.
- 🔧 Simplifies workflow configuration and centralizes maintenance.
- 🚀 May improve consistency and reliability for automated publishing.
- 📦 No direct changes to the Flutter app or its user-facing behavior.