### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Run Ultralytics Actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -58,7 +58,7 @@ jobs:
           git tag -a "${{ github.event.inputs.tag_name }}" -m "$(git log -1 --pretty=%B)"
           git push origin "${{ github.event.inputs.tag_name }}"
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - name: Install dependencies


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚙️ Updated GitHub Actions workflows to use the latest `actions/setup-python@v7`.

### 📊 Key Changes
- Updated `actions/setup-python` from `v6` to `v7` in:
  - Formatting checks
  - Publishing workflow
  - Tagging and release workflow
- No application code or user-facing Flutter functionality was changed.

### 🎯 Purpose & Impact
- ✅ Keeps CI/CD workflows aligned with the latest supported GitHub Action version.
- 🔒 May provide improved compatibility, maintenance, and security for Python environment setup.
- 🚀 Helps ensure formatting, publishing, and release automation remain reliable.