### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/scripts/export-tflite-models.py
+++ b/scripts/export-tflite-models.py
@@ -216,7 +216,7 @@ def run_export_worker(model_id: str, task: TaskSpec, output_dir: Path) -> Path:
         "--worker-imgsz",
         str(task.imgsz),
     ]
-    returncode = subprocess.run(command).returncode
+    returncode = subprocess.run(command, check=False).returncode
     exported = exported_tflite_path(output_dir, model_id)
     if exported is None:
         if returncode != 0:


### PR DESCRIPTION
## Summary
- make the export worker explicit about non-raising subprocess handling for Ruff 0.16.0
- preserve the existing return-code-based error path

## Validation
- pinned Ruff 0.16.0 check and format commands
- Python 3.8 compileall

Deleted: nothing; this replaces an implicit subprocess default with the explicit value required by Ruff while preserving the existing owner and behavior.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved TFLite model export error handling by making subprocess behavior explicit. 🛠️

### 📊 Key Changes

- Updated the export script to call `subprocess.run()` with `check=False`.
- Preserved the existing return-code handling and custom exported-file validation logic.
- Ensured export failures are handled by the script instead of raising an automatic exception.

### 🎯 Purpose & Impact

- Makes the script’s subprocess behavior clearer and more predictable.
- Allows the script to provide its own failure messages and validation results.
- Reduces the risk of unexpected exceptions interrupting the model export workflow. 🚀