### PR TITLE
Bump actions/stale from v10 to v11 in /.github/workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Bump actions/stale from v10 to v11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded the GitHub Actions stale-issue workflow from `actions/stale` v10 to v11. ⚙️

### 📊 Key Changes

- Updated `.github/workflows/stale.yml` to use `actions/stale@v11`.
- No application code or user-facing Flutter functionality was changed.

### 🎯 Purpose & Impact

- Keeps the repository’s automated stale issue and pull request management current. 🔄
- Benefits from updates and maintenance improvements in the newer GitHub Action version.
- Expected to have minimal impact on users and contributors beyond potentially more reliable workflow automation. ✅