### PR TITLE
Increase fast inference task coverage

### DIFF
--- a/test/yolo_inference_test.dart
+++ b/test/yolo_inference_test.dart
@@ -183,8 +183,22 @@ void main() {
             ],
           ],
         },
-        YOLOTask.semantic: {},
-        YOLOTask.depth: {},
+        YOLOTask.semantic: {
+          'semanticMask': {
+            'classMap': [0, 1],
+            'width': 2,
+            'height': 1,
+          },
+        },
+        YOLOTask.depth: {
+          'depthMap': {
+            'values': [1.0, 2.0],
+            'width': 2,
+            'height': 1,
+            'minDepth': 1.0,
+            'maxDepth': 2.0,
+          },
+        },
         YOLOTask.classify: {
           'classification': {'class': 2, 'name': 'bird', 'confidence': 0.8},
         },
@@ -233,8 +247,11 @@ void main() {
         results[YOLOTask.pose]!['detections'],
         contains(containsPair('keypoints', [1.0, 2.0, 0.7, 3.0, 4.0, 0.6])),
       );
-      expect(results[YOLOTask.semantic]!['detections'], isEmpty);
-      expect(results[YOLOTask.depth]!['detections'], isEmpty);
+      for (final task in [YOLOTask.semantic, YOLOTask.depth]) {
+        final payloadKey = responses[task]!.keys.single;
+        expect(results[task]!['detections'], isEmpty);
+        expect(results[task]![payloadKey], responses[task]![payloadKey]);
+      }
       final invalidInference = YOLOInference(
         channel: YOLOTestHelpers.setupMockChannel(
           customResponses: {'predictSingleImage': (_) => 'invalid'},

--- a/test/yolo_inference_test.dart
+++ b/test/yolo_inference_test.dart
@@ -163,30 +163,89 @@ void main() {
       );
     });
 
-    test('predict processes different task types', () async {
-      final tasks = [
-        YOLOTask.detect,
-        YOLOTask.segment,
-        YOLOTask.semantic,
-        YOLOTask.depth,
-        YOLOTask.classify,
-        YOLOTask.pose,
-        YOLOTask.obb,
-      ];
+    test('predict processes task-specific results', () async {
+      final box = {
+        'class': 'person',
+        'confidence': 0.9,
+        'x1': 10.0,
+        'y1': 20.0,
+        'x2': 30.0,
+        'y2': 40.0,
+      };
+      final responses = <YOLOTask, Map<String, dynamic>>{
+        YOLOTask.segment: {
+          'boxes': [box],
+          'masks': [
+            [
+              [0.1, 0.2],
+              [0.3, 0.4],
+            ],
+          ],
+        },
+        YOLOTask.semantic: {},
+        YOLOTask.depth: {},
+        YOLOTask.classify: {
+          'classification': {'class': 2, 'name': 'bird', 'confidence': 0.8},
+        },
+        YOLOTask.pose: {
+          'boxes': [box],
+          'keypoints': [
+            {
+              'coordinates': [
+                {'x': 1, 'y': 2, 'confidence': 0.7},
+                {'x': 3, 'y': 4, 'confidence': 0.6},
+              ],
+            },
+          ],
+        },
+      };
+      final results = <YOLOTask, Map<String, dynamic>>{};
 
-      for (final task in tasks) {
+      for (final entry in responses.entries) {
         final inference = YOLOInference(
-          channel: mockChannel,
+          channel: YOLOTestHelpers.setupMockChannel(
+            customResponses: {'predictSingleImage': (_) => entry.value},
+          ),
           instanceId: 'test_instance',
-          task: task,
+          task: entry.key,
         );
 
-        final imageBytes = Uint8List.fromList([1, 2, 3, 4, 5]);
-        final result = await inference.predict(imageBytes);
-
-        expect(result, isA<Map<String, dynamic>>());
-        expect(result.containsKey('detections'), isTrue);
+        results[entry.key] = await inference.predict(
+          Uint8List.fromList([1, 2, 3]),
+        );
       }
+
+      expect(
+        results[YOLOTask.segment]!['detections'],
+        contains(
+          containsPair('mask', [
+            [0.1, 0.2],
+            [0.3, 0.4],
+          ]),
+        ),
+      );
+      expect(
+        results[YOLOTask.classify]!['detections'],
+        contains(containsPair('className', 'bird')),
+      );
+      expect(
+        results[YOLOTask.pose]!['detections'],
+        contains(containsPair('keypoints', [1.0, 2.0, 0.7, 3.0, 4.0, 0.6])),
+      );
+      expect(results[YOLOTask.semantic]!['detections'], isEmpty);
+      expect(results[YOLOTask.depth]!['detections'], isEmpty);
+      final invalidInference = YOLOInference(
+        channel: YOLOTestHelpers.setupMockChannel(
+          customResponses: {'predictSingleImage': (_) => 'invalid'},
+        ),
+        instanceId: 'test_instance',
+        task: YOLOTask.detect,
+      );
+
+      expect(
+        () => invalidInference.predict(Uint8List.fromList([1])),
+        throwsA(isA<InferenceException>()),
+      );
     });
 
     test('predict with default instance ID', () async {

--- a/test/yolo_inference_test.dart
+++ b/test/yolo_inference_test.dart
@@ -47,6 +47,7 @@ void main() {
       final result = await inference.predict(imageBytes);
 
       expect(result, isA<Map<String, dynamic>>());
+      expect(result['detections'], [containsPair('className', 'person')]);
       YOLOTestHelpers.assertMethodCalled(
         log,
         'predictSingleImage',

--- a/test/yolo_inference_test.dart
+++ b/test/yolo_inference_test.dart
@@ -252,7 +252,10 @@ void main() {
         expect(results[task]!['detections'], isEmpty);
         expect(results[task]![payloadKey], responses[task]![payloadKey]);
       }
-      final invalidInference = YOLOInference(
+    });
+
+    test('predict rejects invalid platform results', () {
+      final inference = YOLOInference(
         channel: YOLOTestHelpers.setupMockChannel(
           customResponses: {'predictSingleImage': (_) => 'invalid'},
         ),
@@ -261,7 +264,7 @@ void main() {
       );
 
       expect(
-        () => invalidInference.predict(Uint8List.fromList([1])),
+        () => inference.predict(Uint8List.fromList([1])),
         throwsA(isA<InferenceException>()),
       );
     });


### PR DESCRIPTION
## Summary
- replace the shallow all-task inference check with behavior assertions for detect, pose, segmentation, classification, semantic, and depth results
- verify dense semantic/depth payloads survive processing
- verify invalid platform results are rejected through the existing error contract

## Results
- CI-filtered coverage: 89.88% (1261/1403) -> 92.16% (1293/1403)
- raw coverage: 85.23% (1818/2133) -> 86.73% (1850/2133)
- test count: 174 -> 175
- full warm suite: 5.06 seconds

## Validation
- `flutter test --coverage`
- CI-equivalent LCOV filter
- `dart analyze --fatal-infos`
- `git diff --check`
- independent cold-context Codex review: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Expanded `YOLOInference` tests to validate task-specific outputs and reject invalid platform responses.

### 📊 Key Changes

- Added detection assertions to confirm class names, such as `person`, are returned correctly.
- Replaced the generic multi-task test with detailed coverage for:
  - Segmentation masks
  - Semantic segmentation payloads
  - Depth maps
  - Classification results
  - Pose keypoints
- Verified that segmentation, classification, and pose data are normalized into the expected `detections` structure.
- Confirmed semantic and depth results preserve their specialized payloads while returning an empty `detections` list.
- Added a test ensuring invalid platform responses trigger an `InferenceException`.

### 🎯 Purpose & Impact

- ✅ Improves confidence that inference results are correctly handled across supported YOLO task types.
- 🛡️ Ensures malformed platform responses fail predictably instead of causing unclear runtime errors.
- 🔍 Provides stronger regression protection for downstream Flutter applications using detection, segmentation, classification, depth, and pose models.