### PR TITLE
Enable multi-threaded LiteRT CPU inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.12
+
+- **Performance**: Use up to four processors available to the Android runtime for faster LiteRT CPU inference while
+  preserving the reported limit on lower-core devices.
+
 ## 0.6.11
 
 - **Fix**: Require UltralyticsYOLO `>= 8.9.13` on iOS for safe float16 object detection decoding.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.6.11
+  ultralytics_yolo: ^0.6.12
 ```
 
 ```bash

--- a/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
@@ -108,6 +108,10 @@ class LiteRtModel(
                 modelCacheKey = "${java.io.File(modelPath).name}_${java.io.File(modelPath).length()}",
                 serializeProgramCache = true,
             )
+        } else {
+            options.cpuOptions = CompiledModel.CpuOptions(
+                numThreads = Runtime.getRuntime().availableProcessors().coerceIn(1, 4),
+            )
         }
         val compiled = CompiledModel.create(modelPath, options)
         val inputs: List<TensorBuffer>

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.11+19
+version: 0.6.12+20
 
 environment:
   sdk: ^3.8.1

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ultralytics_yolo'
-  s.version          = '0.6.11'
+  s.version          = '0.6.12'
   s.summary          = 'Flutter plugin for YOLO (You Only Look Once) models'
   s.description      = <<-DESC
 Flutter plugin for YOLO (You Only Look Once) models, supporting object detection, segmentation, classification, pose estimation and oriented bounding boxes (OBB) on both Android and iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.11
+version: 0.6.12
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
The LiteRT CPU path was running single threaded because prepareModel only configured gpuOptions and LiteRT defaults its CPU options to one XNNPACK thread, so this sets numThreads from availableProcessors capped at 4 and gives a clear speed boost on the CPU fallback path, most visibly on segment (40.0 ms to 28.8 ms) and depth (72.4 ms to 38.7 ms); the numbers below were measured on a Galaxy S26 Ultra (SM-S948B, Snapdragon 8 Elite Gen 5, 8 cores) with the existing integration_test/qnn_benchmark_test.dart harness across all seven tasks at the n model size, and the cap is 4 rather than 8 because 8 threads gave the same average gain but regressed detect and classify. Closes #580.

| task | before (1 thread) | 4 threads | 8 threads | after (cap 4) |
| --- | --- | --- | --- | --- |
| detect | 29.4 ms | 23.6 ms | 27.3 ms | 23.6 ms |
| segment | 40.0 ms | 29.0 ms | 29.0 ms | 28.8 ms |
| semantic | 32.0 ms | 28.1 ms | 23.9 ms | 28.2 ms |
| depth | 72.4 ms | 37.6 ms | 31.3 ms | 38.7 ms |
| classify | 2.1 ms | 2.2 ms | 2.9 ms | 2.4 ms |
| pose | 33.5 ms | 25.2 ms | 23.9 ms | 25.3 ms |
| obb | 29.3 ms | 22.9 ms | 21.3 ms | 23.2 ms |

CPU inference time, lower is better.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
LiteRT CPU inference on Android now uses up to four available processors instead of the default single-thread configuration, improving CPU fallback performance.

### 📊 Key Changes
- Configured `CompiledModel.CpuOptions.numThreads` with the Android runtime’s available processor count, limited to 1–4 threads.
- Applied the thread configuration only to the non-GPU LiteRT path; existing GPU options remain unchanged.
- Updated the plugin and example app versions from `0.6.11` to `0.6.12`, including the changelog, package metadata, iOS podspec, and README dependency example.

### 🎯 Purpose & Impact
- Android LiteRT CPU fallback inference can run with multiple threads, with the reported benchmark showing the largest improvements for segmentation and depth tasks.
- Devices with fewer than four available processors retain their available processor count rather than being forced to use four threads.
- GPU inference configuration and iOS runtime behavior are unchanged.