### PR TITLE
Bump release version to 0.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.12
+## 0.6.13
 
 - **Performance**: Use up to four processors available to the Android runtime for faster LiteRT CPU inference while
   preserving the reported limit on lower-core devices.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package: https://pub.dev/packages/ultralytics_yolo
 
 ```yaml
 dependencies:
-  ultralytics_yolo: ^0.6.12
+  ultralytics_yolo: ^0.6.13
 ```
 
 ```bash

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@
 name: ultralytics_yolo_example
 description: "Demonstrates how to use the ultralytics_yolo plugin."
 publish_to: "none"
-version: 0.6.12+20
+version: 0.6.13+21
 
 environment:
   sdk: ^3.8.1

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ultralytics_yolo'
-  s.version          = '0.6.12'
+  s.version          = '0.6.13'
   s.summary          = 'Flutter plugin for YOLO (You Only Look Once) models'
   s.description      = <<-DESC
 Flutter plugin for YOLO (You Only Look Once) models, supporting object detection, segmentation, classification, pose estimation and oriented bounding boxes (OBB) on both Android and iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.12
+version: 0.6.13
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
## Summary

- bump package, CocoaPods, README, and changelog release version to 0.6.13
- bump the Play example to 0.6.13+21

## Validation

- `dart pub publish --dry-run` (payload valid; pre-commit dirty-tree warning only)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The Flutter plugin release version was updated from 0.6.12 to 0.6.13, including the example app build number and release documentation.

### 📊 Key Changes

- Updated the package version in `pubspec.yaml` and the iOS CocoaPods specification to `0.6.13`.
- Updated the example app version from `0.6.12+20` to `0.6.13+21`.
- Updated the README dependency example to use `ultralytics_yolo: ^0.6.13`.
- Renamed the changelog release heading to `0.6.13`, retaining the existing performance note.

### 🎯 Purpose & Impact

- Publishes the Flutter plugin and its iOS specification under version 0.6.13.
- Updates documented dependency and example app versions for the new release.
- No functional code changes are included.