### PR TITLE
Add the analyzer platform excludes Flutter 3.47 writes during pub get

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,3 +48,10 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    - "build/**"
+    - "android/**"
+    - "ios/**"
+    - "web/**"
+    - "windows/**"
+    - "macos/**"
+    - "linux/**"

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -11,6 +11,16 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - "build/**"
+    - "android/**"
+    - "ios/**"
+    - "web/**"
+    - "windows/**"
+    - "macos/**"
+    - "linux/**"
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`


### PR DESCRIPTION
## summary

- Flutter stable 3.47.0 ships `AnalysisOptionsMigration`, which appends `build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**` and `linux/**` to `analyzer.exclude` whenever a project's own `analysis_options.yaml` is missing any of them. It runs from `ensureReadyForPlatformSpecificTooling`, so `flutter pub get`, `flutter analyze`, `flutter run` and `flutter build` all trigger it, and there is no opt-out flag.
- `flutter pub get` at the repo root also resolves `example/`, so one command rewrites both checked-in `analysis_options.yaml` files. `dart pub publish --dry-run` then reports "2 checked-in files are modified in git" and exits 65 — the only validation finding it reports — which fails `CI / tests` on every PR and on every push to `main`, and the same step in `publish.yml`.
- Committing the seven globs makes the migration a no-op: it compares parsed strings, so quoting does not matter, and it returns before writing once all seven are present. A second `flutter pub get` leaves both files byte-identical.
- No Dart source is tracked under any of those directories in either project, so analyzer coverage is unchanged; the excludes only stop the analyzer from descending into native platform trees, as upstream now intends. Flutter stays on `channel: stable` with no version pin.

## measured

`flutter pub get` on a clean checkout, then `git status --porcelain --untracked-files=no`, then `dart pub publish --dry-run`:

| tree        | Flutter | `Upgrading analysis_options` lines | modified tracked files | dry-run            |
| ----------- | ------- | ---------------------------------- | ---------------------- | ------------------ |
| `main`      | 3.44.9  | 0                                  | 0                      | exit 0, 0 warnings |
| `main`      | 3.47.0  | 2                                  | 2                      | exit 65, 1 warning |
| this branch | 3.44.9  | 0                                  | 0                      | exit 0, 0 warnings |
| this branch | 3.47.0  | 0                                  | 0                      | exit 0, 0 warnings |

On 3.47.0 this branch also passes `flutter test` (175 tests), `dart analyze --fatal-infos` and `flutter analyze`, and the tree is still clean after all three.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Excludes Flutter-generated platform and build files from Dart analyzer checks in both the main app and example project.

### 📊 Key Changes
- Added analyzer exclusions for `build/**` and generated platform directories in the root `analysis_options.yaml`.
- Added matching exclusions to `example/analysis_options.yaml`.
- Covers Android, iOS, Web, Windows, macOS, and Linux Flutter project files.

### 🎯 Purpose & Impact
- Prevents analyzer warnings or errors caused by files generated during `pub get` with Flutter 3.47.
- Keeps static analysis focused on maintained application and example source code.
- Reduces development noise without changing runtime behavior.