### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,10 +51,9 @@ body:
       description: Share the platform and version information relevant to your report.
       placeholder: |
         Please include:
-        - OS (e.g., Ubuntu 20.04, macOS 13.5, Windows 11)
-        - Language or framework version (Python, Swift, Flutter, etc.)
-        - Package or app version
-        - Hardware (e.g., CPU, GPU model, device model)
+        - Device and OS (e.g., Pixel 8 / Android 15, iPhone 15 / iOS 18.2)
+        - Flutter and Dart versions (e.g., flutter --version)
+        - ultralytics_yolo plugin version (e.g., from pubspec.lock)
         - Any other environment details
     validations:
       required: true
@@ -65,8 +64,8 @@ body:
       description: >
         Provide the smallest possible snippet, command, or steps required to reproduce the issue. This helps us pinpoint problems faster.
       placeholder: |
-        ```python
-        # Code or commands to reproduce your issue here
+        ```dart
+        // Code or commands to reproduce your issue here
         ```
     validations:
       required: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,7 +31,7 @@ jobs:
           swift: true # Format Swift (requires a macOS runner)
           dart: true # Format Dart/Flutter
           spelling: true # Check spelling with codespell
-          links: true # Check broken links with Lychee
+          links: false # Lychee link check does not run on macOS runners
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,14 +25,13 @@ jobs:
         uses: ultralytics/actions@main
         with:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated token
-          python-version: "3.13" # Pin to 3.13 to avoid Python 3.14 compatibility issues
           labels: true # Auto-label issues/PRs using AI
-          python: true # Format Python with Ruff and docformatter
+          python: true # Format Python with Ruff
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: true # Format Swift (requires a macOS runner)
           dart: true # Format Dart/Flutter
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution

--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -100,34 +100,32 @@ Future<Map<String, dynamic>> _bench(
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'soak: sustained inference does not exhaust memory',
-    (WidgetTester tester) async {
-      if (!_runSoak || !Platform.isAndroid) {
-        return;
-      }
-      await tester.runAsync(() async {
-        final image = await _download('https://ultralytics.com/images/bus.jpg');
-        // Worst case: semantic logits are the largest output tensors in the model zoo.
-        final yolo = YOLO(
-          modelPath: '$_releaseBase/yolo26n-sem_v${_qnnArch}_qnn.onnx',
-          task: YOLOTask.semantic,
-        );
-        expect(await yolo.loadModel(), isTrue);
-        for (var i = 0; i < 150; i++) {
-          await yolo.predict(image);
-          if (i % 25 == 0) {
-            // ignore: avoid_print
-            print('SOAK|$i');
-          }
+  testWidgets('soak: sustained inference does not exhaust memory', (
+    WidgetTester tester,
+  ) async {
+    if (!_runSoak || !Platform.isAndroid) {
+      return;
+    }
+    await tester.runAsync(() async {
+      final image = await _download('https://ultralytics.com/images/bus.jpg');
+      // Worst case: semantic logits are the largest output tensors in the model zoo.
+      final yolo = YOLO(
+        modelPath: '$_releaseBase/yolo26n-sem_v${_qnnArch}_qnn.onnx',
+        task: YOLOTask.semantic,
+      );
+      expect(await yolo.loadModel(), isTrue);
+      for (var i = 0; i < 150; i++) {
+        await yolo.predict(image);
+        if (i % 25 == 0) {
+          // ignore: avoid_print
+          print('SOAK|$i');
         }
-        await yolo.dispose();
-        // ignore: avoid_print
-        print('SOAK|done');
-      });
-    },
-    timeout: const Timeout(Duration(minutes: 30)),
-  );
+      }
+      await yolo.dispose();
+      // ignore: avoid_print
+      print('SOAK|done');
+    });
+  }, timeout: const Timeout(Duration(minutes: 30)));
 
   testWidgets(
     'benchmark CPU vs preferred platform accelerator and optional QNN',

--- a/example/lib/presentation/screens/single_image_screen.dart
+++ b/example/lib/presentation/screens/single_image_screen.dart
@@ -75,9 +75,8 @@ class _SingleImageScreenState extends State<SingleImageScreen> {
   }
 
   void _showSnackBar(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override

--- a/lib/models/yolo_result.dart
+++ b/lib/models/yolo_result.dart
@@ -4,6 +4,7 @@
 
 import 'dart:typed_data';
 import 'dart:ui';
+
 import '../utils/map_converter.dart';
 
 /// Represents a detection result from YOLO models.

--- a/lib/utils/map_converter.dart
+++ b/lib/utils/map_converter.dart
@@ -2,6 +2,7 @@
 
 import 'dart:typed_data';
 import 'dart:ui';
+
 import '../models/yolo_result.dart';
 
 /// Helpers for adapting loosely-typed platform-channel data

--- a/lib/widgets/yolo_showcase.dart
+++ b/lib/widgets/yolo_showcase.dart
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import 'dart:async';
+
 import 'package:flutter/cupertino.dart' show CupertinoIcons, CupertinoColors;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/lib/yolo_view.dart
+++ b/lib/yolo_view.dart
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import 'dart:async';
+
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/test/mini_zip_test.dart
+++ b/test/mini_zip_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ultralytics_yolo/utils/mini_zip.dart';
+
 import 'utils/test_helpers.dart';
 
 void main() {

--- a/test/yolo_controller_test.dart
+++ b/test/yolo_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ultralytics_yolo/models/yolo_exceptions.dart';
 import 'package:ultralytics_yolo/models/yolo_task.dart';
 import 'package:ultralytics_yolo/widgets/yolo_controller.dart';
+
 import 'utils/test_helpers.dart';
 
 void main() {

--- a/test/yolo_inference_test.dart
+++ b/test/yolo_inference_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ultralytics_yolo/core/yolo_inference.dart';
 import 'package:ultralytics_yolo/models/yolo_task.dart';
 import 'package:ultralytics_yolo/models/yolo_exceptions.dart';
+
 import 'utils/test_helpers.dart';
 
 void main() {

--- a/test/yolo_model_manager_test.dart
+++ b/test/yolo_model_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ultralytics_yolo/core/yolo_model_manager.dart';
 import 'package:ultralytics_yolo/models/yolo_task.dart';
 import 'package:ultralytics_yolo/models/yolo_exceptions.dart';
+
 import 'utils/test_helpers.dart';
 
 void main() {

--- a/test/yolo_result_test.dart
+++ b/test/yolo_result_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:typed_data';
 import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ultralytics_yolo/models/yolo_result.dart';
 

--- a/test/yolo_test.dart
+++ b/test/yolo_test.dart
@@ -17,6 +17,7 @@ import 'package:ultralytics_yolo/utils/error_handler.dart';
 import 'package:ultralytics_yolo/config/channel_config.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:flutter/services.dart';
+
 import 'utils/test_helpers.dart';
 
 class MockYOLOPlatform with MockPlatformInterfaceMixin implements YOLOPlatform {
@@ -1061,9 +1062,8 @@ void main() {
             ? 'assets/custom.mlpackage.zip'
             : 'assets/custom.tflite';
         if (_isAppleTestPlatform) {
-          Directory(
-            '/tmp/yolo_test/yolo26s.mlpackage',
-          ).createSync(recursive: true);
+          Directory('/tmp/yolo_test/yolo26s.mlpackage')
+              .createSync(recursive: true);
         }
         _mockFlutterAssets({officialAsset: bytes, customAsset: bytes});
 

--- a/test/yolo_view_test.dart
+++ b/test/yolo_view_test.dart
@@ -10,6 +10,7 @@ import 'package:ultralytics_yolo/models/yolo_result.dart';
 import 'package:ultralytics_yolo/yolo_performance_metrics.dart';
 import 'package:ultralytics_yolo/yolo_streaming_config.dart';
 import 'package:flutter/foundation.dart';
+
 import 'utils/test_helpers.dart';
 
 void main() {


### PR DESCRIPTION
Aligns the .github directory with the current Ultralytics reference configuration (sdk, skills, openapi, lite).

- format.yml: drop the Python 3.13 pin added for docformatter on Python 3.14; Ultralytics Actions replaced docformatter with its own docstring formatter in Nov 2025, so the pin is dead. The Lychee link check stays disabled because lychee-action does not run on macOS runners (it downloads a Linux binary), and this workflow needs macOS for Swift formatting.
- bug-report.yml: Flutter/Dart environment fields and a Dart code fence in the minimal reproducible example instead of Python.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized the GitHub workflows and bug-report template for Flutter/Dart while applying corresponding Dart formatting updates across the project.

### 📊 Key Changes

- Updated the bug-report template to request device/OS, Flutter/Dart, and `ultralytics_yolo` plugin versions, and changed the reproduction code fence from Python to Dart.
- Removed the pinned Python 3.13 setting and outdated `docformatter` reference from the formatting workflow; clarified why Lychee link checking remains disabled on macOS runners.
- Reformatted the QNN soak test, example UI code, library imports, and test files to match the updated Dart formatting style.

### 🎯 Purpose & Impact

- Improves issue reports by collecting Flutter-specific environment details and Dart reproduction snippets.
- Aligns automated formatting configuration and existing Dart code with the current reference setup.
- No change to YOLO inference, model behavior, or public API behavior.