### PR TITLE
Enable link checks in Ultralytics Actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,7 +31,7 @@ jobs:
           swift: true # Format Swift (requires a macOS runner)
           dart: true # Format Dart/Flutter
           spelling: true # Check spelling with codespell
-          links: false # Lychee link check does not run on macOS runners
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Ultralytics Actions now installs Lychee per runner platform, so link checks work on macOS runners.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Enabled Lychee broken-link checks in the formatting workflow so link validation runs on macOS runners.

### 📊 Key Changes

- Set `links` to `true` in `.github/workflows/format.yml`.
- Activates Lychee link checking through Ultralytics Actions.
- Keeps the existing Swift, Dart, spelling, summary, and API key workflow settings unchanged.

### 🎯 Purpose & Impact

- Pull requests using the formatting workflow will now include automated broken-link checks on macOS runners.