### PR TITLE
Restore Dart tall-style formatting

### DIFF
--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -127,71 +127,69 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 30)));
 
-  testWidgets(
-    'benchmark CPU vs preferred platform accelerator and optional QNN',
-    (WidgetTester tester) async {
-      if (!_runBench || !(Platform.isAndroid || Platform.isIOS)) {
-        return;
-      }
-      await tester.runAsync(() async {
-        final modelSizes = _modelSizes.split(',');
-        expect(modelSizes, everyElement(isIn(['n', 's', 'm', 'l', 'x'])));
-        expect(
-          !_runQnn || modelSizes.every((size) => size == 'n'),
-          isTrue,
-          reason: 'QNN execution supports only the n model size',
-        );
-        final image = await _download('https://ultralytics.com/images/bus.jpg');
-        for (final (index, entry) in _tasks.entries.indexed) {
-          // Rotate model-size order across tasks so no size is systematically measured last.
-          for (var offset = 0; offset < modelSizes.length; offset++) {
-            final modelSize = modelSizes[(index + offset) % modelSizes.length];
-            final (suffix, task) = entry.value;
-            final id = 'yolo26$modelSize$suffix';
-            final accelerator = Platform.isAndroid
-                ? 'gpu-preferred'
-                : 'ane-preferred';
-            final backends = <(String, String, bool)>[
-              ('cpu', id, false),
-              (accelerator, id, true),
-              if (Platform.isAndroid && _runQnn)
-                ('qnn', '$_releaseBase/${id}_v${_qnnArch}_qnn.onnx', true),
-            ];
-            // Rotate backend order across tasks so no enabled backend is systematically measured last.
-            for (var i = 0; i < backends.length; i++) {
-              final (backend, modelPath, useGpu) =
-                  backends[(i + index) % backends.length];
-              final result = await _bench(
-                '$modelSize|${entry.key}|$backend',
-                modelPath,
-                task,
-                image,
-                useGpu: useGpu,
-              );
-              if (backend != 'qnn') continue;
-              final detections =
-                  (result['detections'] as List?)?.cast<Map>() ?? [];
-              final classes = detections.map((d) => d['className']).toSet();
-              switch (entry.key) {
-                case 'detect' || 'segment':
-                  expect(classes, containsAll(['bus', 'person']));
-                case 'pose':
-                  expect(detections, isNotEmpty);
-                case 'classify':
-                  expect(result.containsKey('detections'), isTrue);
-                case 'semantic':
-                  expect(result.containsKey('semanticMask'), isTrue);
-                case 'depth':
-                  expect(result.containsKey('depthMap'), isTrue);
-                case 'obb':
-                  // DOTA aerial classes won't fire on bus.jpg; a clean run is the assertion.
-                  expect(result, isA<Map<String, dynamic>>());
-              }
+  testWidgets('benchmark CPU vs preferred platform accelerator and optional QNN', (
+    WidgetTester tester,
+  ) async {
+    if (!_runBench || !(Platform.isAndroid || Platform.isIOS)) {
+      return;
+    }
+    await tester.runAsync(() async {
+      final modelSizes = _modelSizes.split(',');
+      expect(modelSizes, everyElement(isIn(['n', 's', 'm', 'l', 'x'])));
+      expect(
+        !_runQnn || modelSizes.every((size) => size == 'n'),
+        isTrue,
+        reason: 'QNN execution supports only the n model size',
+      );
+      final image = await _download('https://ultralytics.com/images/bus.jpg');
+      for (final (index, entry) in _tasks.entries.indexed) {
+        // Rotate model-size order across tasks so no size is systematically measured last.
+        for (var offset = 0; offset < modelSizes.length; offset++) {
+          final modelSize = modelSizes[(index + offset) % modelSizes.length];
+          final (suffix, task) = entry.value;
+          final id = 'yolo26$modelSize$suffix';
+          final accelerator = Platform.isAndroid
+              ? 'gpu-preferred'
+              : 'ane-preferred';
+          final backends = <(String, String, bool)>[
+            ('cpu', id, false),
+            (accelerator, id, true),
+            if (Platform.isAndroid && _runQnn)
+              ('qnn', '$_releaseBase/${id}_v${_qnnArch}_qnn.onnx', true),
+          ];
+          // Rotate backend order across tasks so no enabled backend is systematically measured last.
+          for (var i = 0; i < backends.length; i++) {
+            final (backend, modelPath, useGpu) =
+                backends[(i + index) % backends.length];
+            final result = await _bench(
+              '$modelSize|${entry.key}|$backend',
+              modelPath,
+              task,
+              image,
+              useGpu: useGpu,
+            );
+            if (backend != 'qnn') continue;
+            final detections =
+                (result['detections'] as List?)?.cast<Map>() ?? [];
+            final classes = detections.map((d) => d['className']).toSet();
+            switch (entry.key) {
+              case 'detect' || 'segment':
+                expect(classes, containsAll(['bus', 'person']));
+              case 'pose':
+                expect(detections, isNotEmpty);
+              case 'classify':
+                expect(result.containsKey('detections'), isTrue);
+              case 'semantic':
+                expect(result.containsKey('semanticMask'), isTrue);
+              case 'depth':
+                expect(result.containsKey('depthMap'), isTrue);
+              case 'obb':
+                // DOTA aerial classes won't fire on bus.jpg; a clean run is the assertion.
+                expect(result, isA<Map<String, dynamic>>());
             }
           }
         }
-      });
-    },
-    timeout: const Timeout(Duration(minutes: 60)),
-  );
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
 }

--- a/example/integration_test/qnn_benchmark_test.dart
+++ b/example/integration_test/qnn_benchmark_test.dart
@@ -127,69 +127,71 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 30)));
 
-  testWidgets('benchmark CPU vs preferred platform accelerator and optional QNN', (
-    WidgetTester tester,
-  ) async {
-    if (!_runBench || !(Platform.isAndroid || Platform.isIOS)) {
-      return;
-    }
-    await tester.runAsync(() async {
-      final modelSizes = _modelSizes.split(',');
-      expect(modelSizes, everyElement(isIn(['n', 's', 'm', 'l', 'x'])));
-      expect(
-        !_runQnn || modelSizes.every((size) => size == 'n'),
-        isTrue,
-        reason: 'QNN execution supports only the n model size',
-      );
-      final image = await _download('https://ultralytics.com/images/bus.jpg');
-      for (final (index, entry) in _tasks.entries.indexed) {
-        // Rotate model-size order across tasks so no size is systematically measured last.
-        for (var offset = 0; offset < modelSizes.length; offset++) {
-          final modelSize = modelSizes[(index + offset) % modelSizes.length];
-          final (suffix, task) = entry.value;
-          final id = 'yolo26$modelSize$suffix';
-          final accelerator = Platform.isAndroid
-              ? 'gpu-preferred'
-              : 'ane-preferred';
-          final backends = <(String, String, bool)>[
-            ('cpu', id, false),
-            (accelerator, id, true),
-            if (Platform.isAndroid && _runQnn)
-              ('qnn', '$_releaseBase/${id}_v${_qnnArch}_qnn.onnx', true),
-          ];
-          // Rotate backend order across tasks so no enabled backend is systematically measured last.
-          for (var i = 0; i < backends.length; i++) {
-            final (backend, modelPath, useGpu) =
-                backends[(i + index) % backends.length];
-            final result = await _bench(
-              '$modelSize|${entry.key}|$backend',
-              modelPath,
-              task,
-              image,
-              useGpu: useGpu,
-            );
-            if (backend != 'qnn') continue;
-            final detections =
-                (result['detections'] as List?)?.cast<Map>() ?? [];
-            final classes = detections.map((d) => d['className']).toSet();
-            switch (entry.key) {
-              case 'detect' || 'segment':
-                expect(classes, containsAll(['bus', 'person']));
-              case 'pose':
-                expect(detections, isNotEmpty);
-              case 'classify':
-                expect(result.containsKey('detections'), isTrue);
-              case 'semantic':
-                expect(result.containsKey('semanticMask'), isTrue);
-              case 'depth':
-                expect(result.containsKey('depthMap'), isTrue);
-              case 'obb':
-                // DOTA aerial classes won't fire on bus.jpg; a clean run is the assertion.
-                expect(result, isA<Map<String, dynamic>>());
+  testWidgets(
+    'benchmark CPU vs preferred platform accelerator and optional QNN',
+    (WidgetTester tester) async {
+      if (!_runBench || !(Platform.isAndroid || Platform.isIOS)) {
+        return;
+      }
+      await tester.runAsync(() async {
+        final modelSizes = _modelSizes.split(',');
+        expect(modelSizes, everyElement(isIn(['n', 's', 'm', 'l', 'x'])));
+        expect(
+          !_runQnn || modelSizes.every((size) => size == 'n'),
+          isTrue,
+          reason: 'QNN execution supports only the n model size',
+        );
+        final image = await _download('https://ultralytics.com/images/bus.jpg');
+        for (final (index, entry) in _tasks.entries.indexed) {
+          // Rotate model-size order across tasks so no size is systematically measured last.
+          for (var offset = 0; offset < modelSizes.length; offset++) {
+            final modelSize = modelSizes[(index + offset) % modelSizes.length];
+            final (suffix, task) = entry.value;
+            final id = 'yolo26$modelSize$suffix';
+            final accelerator = Platform.isAndroid
+                ? 'gpu-preferred'
+                : 'ane-preferred';
+            final backends = <(String, String, bool)>[
+              ('cpu', id, false),
+              (accelerator, id, true),
+              if (Platform.isAndroid && _runQnn)
+                ('qnn', '$_releaseBase/${id}_v${_qnnArch}_qnn.onnx', true),
+            ];
+            // Rotate backend order across tasks so no enabled backend is systematically measured last.
+            for (var i = 0; i < backends.length; i++) {
+              final (backend, modelPath, useGpu) =
+                  backends[(i + index) % backends.length];
+              final result = await _bench(
+                '$modelSize|${entry.key}|$backend',
+                modelPath,
+                task,
+                image,
+                useGpu: useGpu,
+              );
+              if (backend != 'qnn') continue;
+              final detections =
+                  (result['detections'] as List?)?.cast<Map>() ?? [];
+              final classes = detections.map((d) => d['className']).toSet();
+              switch (entry.key) {
+                case 'detect' || 'segment':
+                  expect(classes, containsAll(['bus', 'person']));
+                case 'pose':
+                  expect(detections, isNotEmpty);
+                case 'classify':
+                  expect(result.containsKey('detections'), isTrue);
+                case 'semantic':
+                  expect(result.containsKey('semanticMask'), isTrue);
+                case 'depth':
+                  expect(result.containsKey('depthMap'), isTrue);
+                case 'obb':
+                  // DOTA aerial classes won't fire on bus.jpg; a clean run is the assertion.
+                  expect(result, isA<Map<String, dynamic>>());
+              }
             }
           }
         }
-      }
-    });
-  }, timeout: const Timeout(Duration(minutes: 60)));
+      });
+    },
+    timeout: const Timeout(Duration(minutes: 60)),
+  );
 }

--- a/example/lib/presentation/screens/single_image_screen.dart
+++ b/example/lib/presentation/screens/single_image_screen.dart
@@ -75,8 +75,9 @@ class _SingleImageScreenState extends State<SingleImageScreen> {
   }
 
   void _showSnackBar(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override

--- a/example/lib/presentation/screens/single_image_screen.dart
+++ b/example/lib/presentation/screens/single_image_screen.dart
@@ -75,9 +75,8 @@ class _SingleImageScreenState extends State<SingleImageScreen> {
   }
 
   void _showSnackBar(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override

--- a/test/yolo_test.dart
+++ b/test/yolo_test.dart
@@ -1062,9 +1062,8 @@ void main() {
             ? 'assets/custom.mlpackage.zip'
             : 'assets/custom.tflite';
         if (_isAppleTestPlatform) {
-          Directory(
-            '/tmp/yolo_test/yolo26s.mlpackage',
-          ).createSync(recursive: true);
+          Directory('/tmp/yolo_test/yolo26s.mlpackage')
+              .createSync(recursive: true);
         }
         _mockFlutterAssets({officialAsset: bytes, customAsset: bytes});
 

--- a/test/yolo_test.dart
+++ b/test/yolo_test.dart
@@ -1062,8 +1062,9 @@ void main() {
             ? 'assets/custom.mlpackage.zip'
             : 'assets/custom.tflite';
         if (_isAppleTestPlatform) {
-          Directory('/tmp/yolo_test/yolo26s.mlpackage')
-              .createSync(recursive: true);
+          Directory(
+            '/tmp/yolo_test/yolo26s.mlpackage',
+          ).createSync(recursive: true);
         }
         _mockFlutterAssets({officialAsset: bytes, customAsset: bytes});
 


### PR DESCRIPTION
Ultralytics Actions reformatted these three files into the pre-3.7 short style in #585 because it ran `dart format` without resolving packages. Restores the tall style produced by `dart format` with the package config resolved (Flutter stable, Dart 3.13.0); ultralytics/actions#876 fixes the action so this does not recur.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Restored Dart’s tall-style formatting in three Flutter/Dart files to match formatting generated with the resolved package configuration.

### 📊 Key Changes

- Reformatted the QNN benchmark test’s `testWidgets` callback and nested control-flow blocks.
- Reformatted the `ScaffoldMessenger.of(context)` call in `SingleImageScreen`.
- Reformatted the temporary `Directory` construction in `yolo_test.dart`.
- No executable logic, test assertions, timeout values, or runtime configuration changed.

### 🎯 Purpose & Impact

- Keeps the affected files consistent with the Dart 3.13.0 formatter output when package resolution is available.
- No user-facing change.