### PR TITLE
Validate the package in the workflow that publishes it

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -23,4 +23,12 @@ jobs:
           cache: true
       - uses: dart-lang/setup-dart@v1
       - run: flutter pub get
+      - name: Validate pub.dev package (includes the iOS Swift Package)
+        shell: bash
+        run: |
+          set -o pipefail
+          dart pub publish --dry-run 2>&1 | tee "$RUNNER_TEMP/dry-run.txt"
+          # Guarantee the SwiftPM manifest ships in the published archive so Swift Package Manager consumers can
+          # resolve the plugin from pub.dev (the CocoaPods podspec ships alongside it for CocoaPods consumers).
+          grep -q 'Package.swift' "$RUNNER_TEMP/dry-run.txt" || { echo "::error::ios/ultralytics_yolo/Package.swift is missing from the pub.dev package"; exit 1; }
       - run: dart pub publish --force


### PR DESCRIPTION
## summary

- `publish.yml`'s `check` job pushes the release tag, and the `build` job holding the only `dart pub publish --dry-run` declares `needs: check`, so validation starts after the tag exists — and the tag push is what triggers `publish-on-tag.yml`. Across all 26 releases the Actions API still holds, the uploading job was already running by the time validation finished; in none of them could it have been blocked.
- `dart pub publish --force` does not stop on a validation warning, so nothing between `flutter pub get` and the upload could catch a bad package. This adds the same validation step to the job that publishes, immediately before `--force`.
- Its log goes to `$RUNNER_TEMP` rather than the package root: an untracked file there enters the published archive, and pub's git-status validator passes `--untracked-files=no`, so a leftover log would ship unnoticed. `publish.yml` is unchanged, since its `build` result drives the release notification.

## measured

Replaying the workflow's step sequence against a local stub pub host, so nothing reaches pub.dev:

| tree | before | after |
| --- | --- | --- |
| fails validation | `--force` runs and POSTs the archive | validation exits 65, `--force` never runs |
| passes validation | `--force` runs | validation exits 0, 0 warnings, `Package.swift` present, `--force` runs |
