### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,11 +6,11 @@ contact_links:
     url: https://github.com/ultralytics/yolo-flutter-app/tree/main/doc
     about: Setup, usage, and performance guides for the Flutter plugin
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask the Ultralytics community for workflow help
   - name: 🎧 Discord
     url: https://ultralytics.com/discord
     about: Chat with the Ultralytics team and other builders
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/ultralytics/
     about: Discuss Ultralytics projects on Reddit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
@@ -10,7 +10,7 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 Ultralytics YOLO Flutter is the official plugin for running YOLO models in Flutter apps on iOS and Android. It supports [detection](https://docs.ultralytics.com/tasks/detect), [instance segmentation](https://docs.ultralytics.com/tasks/segment), [semantic segmentation](https://docs.ultralytics.com/tasks/semantic), depth estimation, [classification](https://docs.ultralytics.com/tasks/classify), [pose](https://docs.ultralytics.com/tasks/pose), and [OBB](https://docs.ultralytics.com/tasks/obb) on both platforms, with two simple entry points:
@@ -302,9 +302,9 @@ Version 0.4.0 removes the old Dart-side overlay/control layer. Camera detections
 
 ## 🤝 Community & Support
 
-[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics) [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/) [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
+[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics) [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com) [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
-- **💬 Questions?** [Discord](https://discord.com/invite/ultralytics) | [Forums](https://community.ultralytics.com/) | [GitHub Issues](https://github.com/ultralytics/yolo-flutter-app/issues)
+- **💬 Questions?** [Discord](https://discord.com/invite/ultralytics) | [Forums](https://community.ultralytics.com) | [GitHub Issues](https://github.com/ultralytics/yolo-flutter-app/issues)
 - **🐛 Found a bug?** [Report it here](https://github.com/ultralytics/yolo-flutter-app/issues/new)
 - **💡 Feature request?** [Let us know](https://github.com/ultralytics/yolo-flutter-app/issues/new)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
@@ -10,7 +10,7 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 Ultralytics YOLO Flutter 是官方 Flutter 插件，用于在 iOS 和 Android 应用中运行 YOLO 模型。它在两个平台上支持[目标检测](https://docs.ultralytics.com/tasks/detect)、[实例分割](https://docs.ultralytics.com/tasks/segment)、[语义分割](https://docs.ultralytics.com/tasks/semantic)、单目深度估计、[图像分类](https://docs.ultralytics.com/tasks/classify)、[姿态估计](https://docs.ultralytics.com/tasks/pose)和[旋转框检测](https://docs.ultralytics.com/tasks/obb)，提供两种核心用法：
@@ -291,9 +291,9 @@ YOLOShowcase(
 
 ## 🤝 社区与支持
 
-[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics) [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/) [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
+[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics) [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com) [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
-- **💬 有问题？** [Discord](https://discord.com/invite/ultralytics) | [Forums](https://community.ultralytics.com/) | [GitHub Issues](https://github.com/ultralytics/yolo-flutter-app/issues)
+- **💬 有问题？** [Discord](https://discord.com/invite/ultralytics) | [Forums](https://community.ultralytics.com) | [GitHub Issues](https://github.com/ultralytics/yolo-flutter-app/issues)
 - **🐛 发现 bug？** [在这里提交](https://github.com/ultralytics/yolo-flutter-app/issues/new)
 - **💡 想提功能建议？** [欢迎告诉我们](https://github.com/ultralytics/yolo-flutter-app/issues/new)
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics YOLO Flutter Example App
 

--- a/ios/ultralytics_yolo/Sources/ultralytics_yolo/README.md
+++ b/ios/ultralytics_yolo/Sources/ultralytics_yolo/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # iOS Native Layer
 


### PR DESCRIPTION
## Summary

URL hygiene pass over the repo: strip terminating path slashes from Ultralytics URLs and refresh links that now permanently redirect. Text-only changes — no Dart, Kotlin, Swift, or build logic touched.

## Trailing slashes (11 fixed across 5 files)

| File                                                    | Fixed | URLs                                              |
| ------------------------------------------------------- | ----- | ------------------------------------------------- |
| `README.md`                                              | 4     | `www.ultralytics.com/`, `community.ultralytics.com/` |
| `README.zh-CN.md`                                        | 4     | `www.ultralytics.com/`, `community.ultralytics.com/` |
| `example/README.md`                                      | 1     | `www.ultralytics.com/`                            |
| `ios/ultralytics_yolo/Sources/ultralytics_yolo/README.md` | 1     | `www.ultralytics.com/`                            |
| `.github/ISSUE_TEMPLATE/config.yml`                      | 1     | `community.ultralytics.com/`                      |

Only slashes that terminate a path were removed — never path separators. A repo-wide re-scan after the edits confirms **zero** remaining terminating slashes on `ultralytics.com` / `*.ultralytics.com` URLs.

Deliberately left untouched:

- `https%3A%2F%2Fcommunity.ultralytics.com` inside the shields.io Forums badge query — URL-encoded parameter, must stay byte-identical.
- `.../releases/download/v0.6.6/<model>_w8a32.tflite` in `doc/models.md` — those slashes are separators before a `<model>` placeholder, and the matching Dart constants (`_androidModelReleaseBaseUrl`, `_iosModelReleaseBaseUrl` in `lib/core/yolo_model_resolver.dart`) already carry no trailing slash, so concatenation is correct.
- `https://ultralytics.com/license` (128 occurrences) — license headers written by Ultralytics Actions; no trailing slash and not ours to rewrite.

## Redirect refresh (1 accepted)

- `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` in `.github/ISSUE_TEMPLATE/config.yml` — canonical host, and now matches the Reddit badge/links already used in both READMEs.

All 51 markdown/HTML link-form URLs plus 122 bare URLs found across `.dart`, `.kt`, `.swift`, `.cpp`, `.h`, `.sh`, `.xml`, `.yml`, and `.md` files were resolved; everything else either already points at its final destination or was rejected below.

### Rejected redirects (judgment calls)

- `https://ultralytics.com/discord` -> `discord.com/invite/...` — vanity shortlink over an expiring invite; the shortlink is the durable form.
- `https://ultralytics.com/license` -> `https://www.ultralytics.com/license` — bot-owned license header string; rewriting it would desync every file from Ultralytics Actions output.
- `https://flutter.dev/to/uiscene-migration`, `https://flutter.dev/to/reference-keystore` — `flutter.dev/to/*` is Flutter's official shortlink namespace, intended to stay a redirect.
- `https://dart.dev/lints`, `https://dart.dev/guides/language/analysis-options`, `https://dart.dev/guides/libraries/private-files#pubspeclock` — comments inside `flutter create` scaffolding (`example/analysis_options.yaml`, `.gitignore`, `example/android/.gitignore`); rewriting third-party template text adds drift for no user benefit.
- `docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates` -> `docs.github.com/en/code-security/reference/...` — destination inserts an `/en/` locale segment absent from the source; locale-pinned URLs are not baked in.
- `https://fsf.org/` -> `https://www.fsf.org/` — inside `LICENSE`; legal text is never edited.
- `http://schemas.android.com/apk/res/android` — XML namespace identifier, not a fetchable URL.
- GitHub release-download base URLs (`.../releases/download/v0.6.6`, `.../releases/download/v8.3.0`) report 404 on a bare request because they are concatenation bases, not pages. Verified in their real role: `.../v8.3.0/yolo11n.mlpackage.zip` returns 200.

### Dead link flagged (no change made, needs a human)

- `pubspec.yaml` `funding:` -> `https://github.com/sponsors/ultralytics` resolves to `https://github.com/ultralytics` (the org profile), i.e. there is no sponsors page behind it. Left as-is rather than baking in a homepage collapse — someone should decide whether to drop the `funding` entry or point it elsewhere.

### Not included: `.github/workflows/stale.yml`

The stale-bot message still links `- **HUB**: https://hub.ultralytics.com`, which permanently redirects to `https://platform.ultralytics.com` (matching the canonical `- **Platform**:` wording used in `ultralytics/ultralytics`). The change was prepared but could not be pushed — the authoring token has no `workflow` scope, so workflow files cannot be updated from this PR. Please apply that one-line update separately.

## Validation

- Regex fixer unit-tested on 29 positive/negative cases before use (subdomains, protocol-relative, fragment/query, sentence-final punctuation, backtick/quote/bracket delimiters; negatives: `github.com/ultralytics/...`, emails, `notultralytics.com`, URL-encoded `https%3A%2F%2F` params, `{placeholder}` templates, ellipsis `/...`).
- `npx prettier@3.8.5 --check` passes on every changed file.
- Both changed YAML files parse cleanly; `contact_links` URLs verified serially (all 200).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated repository documentation and issue-template links to remove unnecessary trailing slashes and use the canonical Reddit URL without changing application or build code.

### 📊 Key Changes

- Removed terminating slashes from Ultralytics website and community forum links in the English and Chinese READMEs, example README, iOS README, and issue-template configuration.
- Updated the Reddit issue-template link from `reddit.com/r/ultralytics` to `www.reddit.com/r/ultralytics/`.
- Preserved URL-encoded badge parameters, path separators in download URLs, license headers, and third-party template links.
- No changes were made to `.github/workflows/stale.yml`; its `hub.ultralytics.com` link remains unchanged.

### 🎯 Purpose & Impact

- Documentation and issue-template links now use the selected canonical URL forms.
- **No user-facing change** to Flutter, Android, iOS, Dart, or build behavior.