### PR TITLE
Recognize current output0 tensor names in LiteRT models

### DIFF
--- a/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
+++ b/android/src/main/kotlin/com/ultralytics/yolo/LiteRtModel.kt
@@ -20,7 +20,8 @@ import kotlin.math.sqrt
  * accelerator, so a model either runs fully on GPU or fully on CPU - no per-op fragmentation.
  *
  * Input tensor name is `images` for legacy onnx2tf exports and `args_0` for litert-torch (`format=litert`) exports;
- * outputs are `output_0`, `output_1`, ... for litert-torch and `Identity`, `Identity_1`, ... for legacy onnx2tf.
+ * outputs can be `output_0`, `output_1`, ... for litert-torch, `output0`, `output1`, ... for current Ultralytics
+ * TFLite exports, or `Identity`, `Identity_1`, ... for legacy onnx2tf.
  *
  * Input layout is detected from the input tensor shape: legacy onnx2tf exports are NHWC `[1,H,W,3]`, while
  * `format=litert` (litert-torch) exports are NCHW `[1,3,H,W]`. [inputDims] is always reported in the NHWC convention so
@@ -166,12 +167,12 @@ class LiteRtModel(
                 compiled.run(inputs, outputs)
             }
             val outputTensorTypes = List(outputs.size) { i ->
-                // litert-torch (format=litert) names signature outputs output_0, output_1, …; legacy onnx2tf exports
-                // name them Identity, Identity_1, …. Try both so the output shape resolves for either export: a missed
-                // shape leaves outputDims empty, which breaks the segment/semantic/pose predictors that read it (the
+                // litert-torch (format=litert) names signature outputs output_0, output_1, …; current TFLite exports
+                // use output0, output1, …; legacy onnx2tf uses Identity, Identity_1, …. Try every supported spelling;
+                // a miss leaves outputDims empty, which breaks the segment/semantic/pose predictors that read it (the
                 // detect/obb/classify heads fall back to the element count, so they survive a miss).
                 val legacyName = if (i == 0) "Identity" else "Identity_$i"
-                sequenceOf("output_$i", legacyName).firstNotNullOfOrNull { name ->
+                sequenceOf("output_$i", "output$i", legacyName).firstNotNullOfOrNull { name ->
                     try {
                         compiled.getOutputTensorType(outputName = name)
                     } catch (e: Throwable) {


### PR DESCRIPTION
## Summary

- probe current Ultralytics TFLite output names (`output0`, `output1`, ...) when resolving LiteRT output tensor types
- preserve the existing `output_0` and `Identity` lookup paths for LiteRT-Torch and legacy onnx2tf exports
- document the three supported output naming conventions next to the loader

## Why

Current Ultralytics YOLO26 TFLite exports can name their outputs `output0`, `output1`, and so on. The Android loader currently probes only `output_0` and `Identity` variants. When the lookup misses, output dimensions remain empty. Detect, OBB, and classify can sometimes fall back to the flat element count, but depth, segmentation, semantic segmentation, and pose parsing require the resolved shape.

This is an additive name lookup only; it does not alter model execution, tensor contents, or support for older exports.

## Validation

- built the plugin through the Stocadro Android app/package matrix
- ran YOLO26 metric-depth inference on an Android 36 emulator
- verified the exported `output0` tensor resolves its dimensions and produces a 572x768 depth map
- Android Patrol feature proof passed with median object depth 0.985 m

The branch contains only the loader change; the separate AGP migration experiment is intentionally excluded.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The LiteRT Android loader now recognizes current Ultralytics TFLite output names such as `output0` while retaining support for `output_0` and `Identity` naming conventions, allowing output tensor types and dimensions to resolve correctly.

### 📊 Key Changes
- Documents the three supported output naming conventions in `LiteRtModel.kt`.
- Probes `output_$i`, `output$i`, and the legacy `Identity` naming pattern when resolving output tensor types.
- Preserves existing LiteRT-Torch and legacy onnx2tf lookup paths.
- Prevents unresolved output dimensions for models using current `output0`, `output1`, and similar names.

### 🎯 Purpose & Impact
Models with current Ultralytics TFLite output names can now provide resolved output dimensions to depth, segmentation, semantic segmentation, and pose predictors; no model execution or tensor contents are changed.