### PR TITLE
Reuse the UltralyticsYOLO label parser in iOS inspectModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.14
+
+- **Fix**: Reuse the UltralyticsYOLO label parser on iOS so `names` metadata in list form, with double-quoted keys, or
+  with a negative key no longer yields wrong labels or traps. Requires UltralyticsYOLO `>= 8.9.14`.
+
 ## 0.6.13
 
 - **Performance**: Use up to four processors available to the Android runtime for faster LiteRT CPU inference while

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "6931313992cf3bb97f2f1159cf26c834d4714c7b",
-        "version" : "8.9.13"
+        "revision" : "6df594843983c38083ef7db014a0fcd756039d2f",
+        "version" : "8.9.14"
       }
     }
   ],

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ultralytics/yolo-ios-app.git",
       "state" : {
-        "revision" : "6931313992cf3bb97f2f1159cf26c834d4714c7b",
-        "version" : "8.9.13"
+        "revision" : "6df594843983c38083ef7db014a0fcd756039d2f",
+        "version" : "8.9.14"
       }
     }
   ],

--- a/ios/ultralytics_yolo.podspec
+++ b/ios/ultralytics_yolo.podspec
@@ -19,7 +19,7 @@ Flutter plugin for YOLO (You Only Look Once) models, supporting object detection
   # "no rule to process file ... net.daringfireball.markdown" warning Xcode emits when README.md is swept in.
   s.source_files = 'ultralytics_yolo/Sources/ultralytics_yolo/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'UltralyticsYOLO', '>= 8.9.13', '< 9.0'
+  s.dependency 'UltralyticsYOLO', '>= 8.9.14', '< 9.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/ultralytics_yolo/Package.swift
+++ b/ios/ultralytics_yolo/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   ],
   dependencies: [
     // Shared YOLO inference core, the single source of truth for iOS (https://github.com/ultralytics/yolo-ios-app).
-    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.13', '< 9.0'` range in the podspec.
-    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.13"..<"9.0.0")
+    // Mirrors the CocoaPods `s.dependency 'UltralyticsYOLO', '>= 8.9.14', '< 9.0'` range in the podspec.
+    .package(url: "https://github.com/ultralytics/yolo-ios-app.git", "8.9.14"..<"9.0.0")
   ],
   targets: [
     .target(

--- a/ios/ultralytics_yolo/Sources/ultralytics_yolo/YOLOPlugin.swift
+++ b/ios/ultralytics_yolo/Sources/ultralytics_yolo/YOLOPlugin.swift
@@ -20,7 +20,7 @@ final class SendableBox<T>: @unchecked Sendable {
 // the FlutterPlugin protocol predates Swift concurrency and isn't `@MainActor`-isolated. Without this annotation
 // Xcode 26.5 prints "Conformance crosses into main actor-isolated code and can cause data races" for our
 // `@MainActor` class. `@unchecked Sendable` lets the inspectModel background dispatch capture `self`; the methods
-// it invokes (`checkModelExists`, `inspectModel`, `parseLabels`) are `nonisolated` and read no mutable state.
+// it invokes (`checkModelExists`, `inspectModel`) are `nonisolated` and read no mutable state.
 @MainActor
 public final class YOLOPlugin: NSObject, @preconcurrency FlutterPlugin, @unchecked Sendable {
   // Static channel-registry and registrar storage live on the main actor with the class. `@MainActor` here is
@@ -159,8 +159,8 @@ public final class YOLOPlugin: NSObject, @preconcurrency FlutterPlugin, @uncheck
   }
 
   // `nonisolated static` so we can dispatch the heavy MLModel.compileModel + load off the main thread without
-  // crossing `@MainActor` or capturing `self`. `checkModelExists` and `parseLabels` below are pure (no main-actor
-  // state), so calling them from a background queue is safe.
+  // crossing `@MainActor` or capturing `self`. `checkModelExists` is pure (no main-actor
+  // state), so calling it from a background queue is safe.
   nonisolated static func inspectModel(modelPath: String) throws -> [String: Any] {
     let checkResult = checkModelExists(modelPath: modelPath)
     let resolvedPath = (checkResult["absolutePath"] as? String) ?? modelPath
@@ -178,7 +178,7 @@ public final class YOLOPlugin: NSObject, @preconcurrency FlutterPlugin, @uncheck
     let creatorDefined =
       model.modelDescription.metadata[MLModelMetadataKey.creatorDefinedKey] as? [String: String]
       ?? [:]
-    let labels = parseLabels(from: creatorDefined)
+    let labels = BasePredictor.parseLabels(from: creatorDefined)
 
     var result: [String: Any] = [
       "path": resolvedPath,
@@ -206,55 +206,6 @@ public final class YOLOPlugin: NSObject, @preconcurrency FlutterPlugin, @uncheck
     }
 
     return result
-  }
-
-  nonisolated private static func parseLabels(from userDefined: [String: String]) -> [String] {
-    if let labelsData = userDefined["classes"] {
-      return
-        labelsData
-        .components(separatedBy: ",")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-    }
-
-    if let labelsData = userDefined["names"] {
-      let cleanedInput =
-        labelsData
-        .replacingOccurrences(of: "{", with: "")
-        .replacingOccurrences(of: "}", with: "")
-
-      let parsedPairs = cleanedInput.components(separatedBy: ",").compactMap {
-        pair -> (Int?, String)? in
-        let components = pair.split(
-          separator: ":",
-          maxSplits: 1,
-          omittingEmptySubsequences: false
-        )
-        guard components.count >= 2 else { return nil }
-
-        let key = Int(String(components[0]).trimmingCharacters(in: .whitespacesAndNewlines))
-        let value = String(components[1])
-          .trimmingCharacters(in: .whitespacesAndNewlines)
-          .replacingOccurrences(of: "'", with: "")
-        return (key, value)
-      }
-
-      let keyedLabels = parsedPairs.compactMap { key, value -> (Int, String)? in
-        guard let key else { return nil }
-        return (key, value)
-      }
-      if !keyedLabels.isEmpty {
-        let maxKey = keyedLabels.map(\.0).max() ?? -1
-        var labels = Array(repeating: "", count: maxKey + 1)
-        for (key, value) in keyedLabels {
-          labels[key] = value
-        }
-        return labels
-      }
-
-      return parsedPairs.map { $0.1 }
-    }
-
-    return []
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: ultralytics_yolo
 description: Flutter plugin for Ultralytics YOLO computer vision models.
-version: 0.6.13
+version: 0.6.14
 homepage: https://github.com/ultralytics/yolo-flutter-app
 repository: https://github.com/ultralytics/yolo-flutter-app
 issue_tracker: https://github.com/ultralytics/yolo-flutter-app/issues


### PR DESCRIPTION
> **Blocked on ultralytics/yolo-ios-app#315** (merged; waiting on the `v8.9.14` tag). Until that release exists the SwiftPM pin cannot resolve and `example-ios` fails. Draft until the tag is live and both `Package.resolved` files are regenerated.

`YOLOPlugin.inspectModel` carried its own 48-line copy of the SDK's label parser instead of calling it. The copy had drifted and is the buggier of the two, so deleting it fixes three real defects rather than merely deduplicating:

| `names` metadata | SDK parser | the copy being deleted |
| --- | --- | --- |
| list form `"['person','car']"` | parses | never strips `[`/`]`, and `guard components.count >= 2 else { return nil }` drops every unkeyed entry → returns `[]` |
| double-quoted keys `{"0": "person"}` | strips `"` from key and value | strips only `'`, only from the value → `Int("\"0\"")` is `nil`, entry dropped; surviving labels keep literal quotes |
| negative key | guarded with `where key >= 0` | writes `labels[key]` unguarded → **`Index out of range` trap** inside the background `inspectModel` dispatch |

**Scope of the impact:** these affect the `inspectModel` method-channel result only (`YOLOPlugin.swift:186`, `"labels": labels`). They do **not** affect on-device detection labels — those come from the SDK's own parser at load time (`BasePredictor.swift:274`), which already handles all three cases. So the practical effect is that `inspectModel` starts agreeing with the labels inference already reports; it removes an inconsistency rather than fixing mislabeled detections. The `Index out of range` trap is the one case that is a hard failure rather than a disagreement.

It also closes an iOS/Android divergence: `YOLOFileUtils.kt:313` `parseNames` already handles the list form, so iOS was the odd one out.

## Changes

- `YOLOPlugin.swift` — delete the private `parseLabels` copy; call `BasePredictor.parseLabels` instead. `import UltralyticsYOLO` was already present, and `BasePredictor` is not `@MainActor`, so the `nonisolated` background call stays valid. Two comments naming the deleted function updated.
- Pin `UltralyticsYOLO >= 8.9.14` in `Package.swift` and the podspec; bump plugin to `0.6.14`.

**Net −49 lines of code.** No Dart changes: `inspectModel`'s `{path, task, labels, ...}` channel contract is unchanged, and `test/yolo_test.dart` mocks the channel.

## Deliberately not included

- `checkModelExists` and the body of `inspectModel` — not duplication. Flutter-asset bundle-layout probing has no SDK counterpart, and `ModelPathResolver` is internal and handles only absolute paths plus bare bundle resource names.
- New SDK accessors for `task`/`imgsz`/`stride`/`channels`/`end2end` — nothing in `lib/` reads them; only `metadata['task']` is consumed.
- Any `.aimodel`/Core AI work. The format cannot load here: `UltralyticsYOLO` has no Core AI predictor, `CoreAI.framework` is absent from the Simulator SDK, and both build systems floor at iOS 13 against its iOS 27 requirement.

## Validation

`flutter test` → **175 passed**. `dart analyze --fatal-infos` → **No issues found!** (`example/integration_test/qnn_benchmark_test.dart` reports a `dart format` diff on unmodified `main` too — pre-existing, left alone.)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

iOS `inspectModel` now uses the shared `BasePredictor.parseLabels` implementation, fixing inconsistent `names` metadata parsing and requiring UltralyticsYOLO `8.9.14` or newer.

### 📊 Key Changes

- Replaced the duplicated private label parser in `YOLOPlugin.swift` with `BasePredictor.parseLabels`.
- `inspectModel` now correctly handles list-form names, double-quoted keys and values, and negative keys without dropping labels or triggering an index-out-of-range trap.
- Updated the iOS Swift Package Manager and CocoaPods dependency ranges to `>= 8.9.14`, and refreshed both example iOS package lockfiles to version `8.9.14`.
- Bumped the Flutter plugin version to `0.6.14`; the Dart method-channel contract remains unchanged.

### 🎯 Purpose & Impact

- The iOS `inspectModel` result now uses the same label parsing behavior as on-device inference and Android parsing; detection labels themselves are unchanged.
- Negative label keys no longer cause `inspectModel` to fail while running its background dispatch.