### PR TITLE
Update mobile exports for unified nms arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ dart pub publish --dry-run                  # pub.dev package validation, run by
 
 - CI (`ci.yml`) runs three jobs on push/PR to main: `tests` (ubuntu-latest: tests + coverage + publish dry-run), `example-android` (ubuntu-latest: debug APK, API 34 emulator smoke test, release AAB verified with `scripts/build_play_store_assets.sh --verify-aab`), and `example-ios` (macos-26: SwiftPM build + simulator smoke test, then a CocoaPods regression build of the same sources).
 - Version floors are Dart SDK `^3.8.1` and Flutter `>=3.32.1` (pubspec.yaml); CI uses the stable Flutter channel.
-- Model export requires `ultralytics>=8.4.142`: LiteRT uses `nms=None` for raw one-to-many outputs, while Core ML assets use `nms=False` for the NMS-free head. `end2end` remains graph metadata, not an export argument.
+- Model export requires `ultralytics>=8.4.142`: LiteRT uses `nms=None` for raw one-to-many outputs, while Core ML assets use `nms=False` for the NMS-free head. `end2end` describes graph metadata; use `nms` to configure exports.
 - For the Python model-export tooling use `uv pip install`, never bare `pip install` (see the header of `scripts/export-tflite-models.py`).
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ dart pub publish --dry-run                  # pub.dev package validation, run by
 
 - CI (`ci.yml`) runs three jobs on push/PR to main: `tests` (ubuntu-latest: tests + coverage + publish dry-run), `example-android` (ubuntu-latest: debug APK, API 34 emulator smoke test, release AAB verified with `scripts/build_play_store_assets.sh --verify-aab`), and `example-ios` (macos-26: SwiftPM build + simulator smoke test, then a CocoaPods regression build of the same sources).
 - Version floors are Dart SDK `^3.8.1` and Flutter `>=3.32.1` (pubspec.yaml); CI uses the stable Flutter channel.
+- Model export requires `ultralytics>=8.4.142`: LiteRT uses `nms=None` for raw one-to-many outputs, while Core ML assets use `nms=False` for the NMS-free head. `end2end` remains graph metadata, not an export argument.
 - For the Python model-export tooling use `uv pip install`, never bare `pip install` (see the header of `scripts/export-tflite-models.py`).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Pass an `http` or `https` URL and the plugin will download it into app storage b
 
 Android ships with LiteRT (TFLite) and that remains the default — nothing changes for existing apps, and the
 QNN support adds zero bytes to your build. Any model path ending in `_qnn.onnx` (a Qualcomm QNN context binary
-exported with `yolo export format=qnn imgsz=640`, or `imgsz=224` for classification) is routed to the Hexagon NPU through the ONNX Runtime QNN Execution
-Provider instead.
+exported with `yolo export model=yolo26n.pt format=qnn nms=None imgsz=640`, or `imgsz=224` for classification) is routed to the Hexagon NPU through the ONNX Runtime QNN Execution
+Provider instead. With `ultralytics>=8.4.142`, `nms=None` selects raw one-to-many outputs for Android-side NMS.
 
 Running QNN models requires a Snapdragon device with a Hexagon HTP (Snapdragon 8 Gen 2 or newer for the official
 `_v73` assets; `_v81` targets Snapdragon 8 Elite Gen 5) and three additions to your app's
@@ -224,6 +224,7 @@ with Ultralytics using the same task-specific `imgsz`. Core ML assets are genera
 Android inference runs on [LiteRT](https://developers.google.com/edge/litert) 2.x through an automatic GPU -> CPU accelerator ladder. w8a32 assets are the official download artifacts (the smallest GPU-compatible litert format); the GPU delegate compiles the whole graph on supported devices and otherwise falls back to CPU. GPU coverage still depends on the device driver and graph, so confirm delegate placement on your target hardware (the GPU delegate runs the graph in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
 from ultralytics import YOLO
 
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Run it on Linux x86 or macOS with Python ≥3.10:
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
+uv pip install --torch-backend cpu "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ Run it on Linux x86 or macOS with Python ≥3.10:
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.83"
+uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 
@@ -227,7 +226,7 @@ Android inference runs on [LiteRT](https://developers.google.com/edge/litert) 2.
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,7 +204,7 @@ Android TFLite release 资产由 [`scripts/export-tflite-models.py`](scripts/exp
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
+uv pip install --torch-backend cpu "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,7 +145,7 @@ final yolo = YOLO(
 
 ### 4. 高通 NPU 模型（Android，可选启用）
 
-Android 默认使用 LiteRT（TFLite），这一点保持不变——现有应用无需任何改动，QNN 支持也不会给你的构建增加任何体积。任何以 `_qnn.onnx` 结尾的模型路径（通过 `yolo export format=qnn imgsz=640` 导出，分类任务使用 `imgsz=224`）都会改由 ONNX Runtime QNN Execution Provider 路由到 Hexagon NPU 上运行。
+Android 默认使用 LiteRT（TFLite），这一点保持不变——现有应用无需任何改动，QNN 支持也不会给你的构建增加任何体积。任何以 `_qnn.onnx` 结尾的模型路径（通过 `yolo export model=yolo26n.pt format=qnn nms=None imgsz=640` 导出，分类任务使用 `imgsz=224`）都会改由 ONNX Runtime QNN Execution Provider 路由到 Hexagon NPU 上运行。使用 `ultralytics>=8.4.142` 时，`nms=None` 选择原始一对多输出，由 Android 端执行 NMS。
 
 运行 QNN 模型需要配备 Hexagon HTP 的 Snapdragon 设备（官方 `_v73` 资产要求 Snapdragon 8 Gen 2 或更新；`_v81` 面向 Snapdragon 8 Elite Gen 5），并在应用的 `android/app/build.gradle` 中添加三处配置：
 
@@ -213,6 +213,7 @@ uv run python scripts/export-tflite-models.py --verify
 Android 推理运行在 [LiteRT](https://developers.google.com/edge/litert) 2.x 之上，带有自动的 GPU -> CPU 加速器降级链。w8a32 资产作为官方下载产物（最小的可在 GPU 上编译的 litert 格式）；在受支持的设备上，GPU delegate 会编译整个计算图，否则回退到 CPU。GPU 覆盖仍取决于设备驱动和计算图，因此请在目标硬件上确认 delegate 的放置（GPU delegate 以 FP16 运行计算图）：
 
 ```python
+# Requires ultralytics>=8.4.142
 from ultralytics import YOLO
 
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,8 +204,7 @@ Android TFLite release 资产由 [`scripts/export-tflite-models.py`](scripts/exp
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.83"
+uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 
@@ -216,7 +215,7 @@ Android 推理运行在 [LiteRT](https://developers.google.com/edge/litert) 2.x 
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # 分类模型使用 imgsz=224。
 ```
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -185,6 +185,9 @@ iOS inference runs on Core ML, which automatically uses the Neural Engine and GP
 Android inference runs on LiteRT 2.x via `CompiledModel`, which automatically tries a GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. Confirm actual delegate placement from device logs. non-end-to-end exports are still useful for GPU benchmarking (the GPU delegate runs them in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
+from ultralytics import YOLO
+
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```

--- a/doc/install.md
+++ b/doc/install.md
@@ -185,7 +185,7 @@ iOS inference runs on Core ML, which automatically uses the Neural Engine and GP
 Android inference runs on LiteRT 2.x via `CompiledModel`, which automatically tries a GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. Confirm actual delegate placement from device logs. non-end-to-end exports are still useful for GPU benchmarking (the GPU delegate runs them in FP16):
 
 ```python
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/doc/models.md
+++ b/doc/models.md
@@ -76,7 +76,7 @@ Official export properties:
 Export scripts require `ultralytics>=8.4.142`. LiteRT uses `nms=None` for raw one-to-many outputs with Android-side
 NMS. Core ML uses `nms=False` for NMS-free detect, segment, pose, and OBB outputs; classification, semantic, and depth
 retain their native outputs. `nms=True` embeds NMS where supported. The `end2end` metadata field describes the
-exported graph, not an export argument. Android `w8a32` uses int8 weights and FP32 activations without calibration.
+exported graph; use `nms` to configure exports. Android `w8a32` uses int8 weights and FP32 activations without calibration.
 
 If you want the simplest “start from the default Ultralytics model” entry point, prefer `YOLO.defaultOfficialModel()`.
 
@@ -202,7 +202,7 @@ Use Linux x86 or macOS with Python ≥3.10 for LiteRT export.
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
+uv pip install --torch-backend cpu "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 

--- a/doc/models.md
+++ b/doc/models.md
@@ -68,16 +68,15 @@ Official export properties:
 | Format         | `.tflite`                                     | `.mlpackage.zip`                        |
 | Quantization   | w8a32 LiteRT (int8 weights, FP32 activations) | int8 Core ML                            |
 | `imgsz`        | `224` cls; `640` others                       | `224` cls; `640` others                 |
-| `nms`          | `False`                                       | `False`                                 |
-| `end2end`      | `False`                                       | `False` cls/sem/depth; `True` others    |
+| `nms`          | `None`                                       | `False`                                 |
+| `end2end` metadata      | `False`                                       | `False` cls/sem/depth; `True` others    |
 | Calibration    | None (w8a32 dynamic-range)                    | exporter default                        |
 | Postprocessing | Android native                                | Swift/Core ML                           |
 
-The TFLite export script passes both `nms=False` and `end2end=False`. `nms=False` excludes an exported NMS operator,
-while `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path. The shipped Core ML
-assets use `end2end=True` for detect, segment, pose, and OBB and `end2end=False` for classification, semantic, and
-depth. The Android `w8a32` export is dynamic-range quantization (int8 weights, FP32 activations), so it needs no
-calibration data.
+Export scripts require `ultralytics>=8.4.142`. LiteRT uses `nms=None` for raw one-to-many outputs with Android-side
+NMS. Core ML uses `nms=False` for NMS-free detect, segment, pose, and OBB outputs; classification, semantic, and depth
+retain their native outputs. `nms=True` embeds NMS where supported. The `end2end` metadata field describes the
+exported graph, not an export argument. Android `w8a32` uses int8 weights and FP32 activations without calibration.
 
 If you want the simplest “start from the default Ultralytics model” entry point, prefer `YOLO.defaultOfficialModel()`.
 
@@ -203,8 +202,7 @@ Use Linux x86 or macOS with Python ≥3.10 for LiteRT export.
 
 ```bash
 uv venv --python 3.12 .venv
-uv pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
-uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.83"
+uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
 uv run python scripts/export-tflite-models.py --verify
 ```
 
@@ -219,7 +217,7 @@ Android inference runs on LiteRT 2.x with an automatic GPU -> CPU accelerator la
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/doc/models.md
+++ b/doc/models.md
@@ -210,11 +210,12 @@ Use `--upload --repo ultralytics/yolo-flutter-app --tag v0.6.6` to replace the e
 script exports YOLO26 `n/s/m/l/x` models for every task in its `TASKS` registry, including depth. Output files are
 written under `exports/yolo26-tflite/release-assets/` and are ignored by Git. The `w8a32` format (int8 weights, FP32
 activations) is dynamic-range quantization, so no calibration data is required. Use Ultralytics QNN export on a
-supported QNN export host to export the matching nano QNN assets for HTP v73 and v81.
+supported QNN export host with `ultralytics>=8.4.142` and `nms=None` to export the matching nano QNN assets for HTP v73 and v81. QNN uses raw one-to-many outputs with Android-side NMS; it does not support the NMS-free head or embedded NMS.
 
 Android inference runs on LiteRT 2.x with an automatic GPU -> CPU accelerator ladder. w8a32 assets are the official download artifacts (the smallest GPU-compatible litert format); the GPU delegate compiles the whole graph on supported devices and otherwise falls back to CPU. GPU coverage still depends on the device driver and graph, so confirm delegate placement on your target hardware (the GPU delegate runs the graph in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
 from ultralytics import YOLO
 
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)

--- a/doc/models.md
+++ b/doc/models.md
@@ -61,17 +61,17 @@ constants, docs, and URL tests in the same PR.
 
 Official export properties:
 
-| Property       | TFLite                                        | Core ML                                 |
-| -------------- | --------------------------------------------- | --------------------------------------- |
-| Model IDs      | `yolo26{n,s,m,l,x}`                           | `yolo26{n,s,m,l,x}`                     |
-| Tasks          | detect, seg, sem, depth, cls, pose, obb       | detect, seg, sem, depth, cls, pose, obb |
-| Format         | `.tflite`                                     | `.mlpackage.zip`                        |
-| Quantization   | w8a32 LiteRT (int8 weights, FP32 activations) | int8 Core ML                            |
-| `imgsz`        | `224` cls; `640` others                       | `224` cls; `640` others                 |
-| `nms`          | `None`                                       | `False`                                 |
-| `end2end` metadata      | `False`                                       | `False` cls/sem/depth; `True` others    |
-| Calibration    | None (w8a32 dynamic-range)                    | exporter default                        |
-| Postprocessing | Android native                                | Swift/Core ML                           |
+| Property           | TFLite                                        | Core ML                                 |
+| ------------------ | --------------------------------------------- | --------------------------------------- |
+| Model IDs          | `yolo26{n,s,m,l,x}`                           | `yolo26{n,s,m,l,x}`                     |
+| Tasks              | detect, seg, sem, depth, cls, pose, obb       | detect, seg, sem, depth, cls, pose, obb |
+| Format             | `.tflite`                                     | `.mlpackage.zip`                        |
+| Quantization       | w8a32 LiteRT (int8 weights, FP32 activations) | int8 Core ML                            |
+| `imgsz`            | `224` cls; `640` others                       | `224` cls; `640` others                 |
+| `nms`              | `None`                                        | `False`                                 |
+| `end2end` metadata | `False`                                       | `False` cls/sem/depth; `True` others    |
+| Calibration        | None (w8a32 dynamic-range)                    | exporter default                        |
+| Postprocessing     | Android native                                | Swift/Core ML                           |
 
 Export scripts require `ultralytics>=8.4.142`. LiteRT uses `nms=None` for raw one-to-many outputs with Android-side
 NMS. Core ML uses `nms=False` for NMS-free detect, segment, pose, and OBB outputs; classification, semantic, and depth

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -341,6 +341,7 @@ The official YOLO26 Android assets (w8a32 LiteRT) compile on the LiteRT GPU path
 non-end-to-end LiteRT exports are still useful for GPU benchmarking (the GPU delegate runs them in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
 from ultralytics import YOLO
 
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -411,7 +411,7 @@ This is the canonical record of the on-device profiling behind the Ultralytics Y
 
 - **Device (ground truth):** Samsung Galaxy S26 (`SM S9420`), Android 16 / API 36.
 - **Build:** Flutter example debug APK, package `com.ultralytics.yolo`.
-- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `quantize=8`, `nms=None` (Ultralytics >=8.4.142; originally `nms=False, end2end=False`).
+- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `quantize=8`, `nms=False, end2end=False` (equivalent to `nms=None` with Ultralytics >=8.4.142).
 - **Runtime:** Android LiteRT 2.x `CompiledModel` with `useGpu: true`.
 - **UI:** `YOLOShowcase` real-time camera view with the default task/size controls and threshold sliders.
 - **Numbers:** EMA-smoothed app metrics after the camera and model are warm.
@@ -510,7 +510,7 @@ The app UI correctly showed the resolver failure. To validate the camera/inferen
 ### Current Shipped Configuration
 
 - Android official assets: YOLO26 w8a32 `.tflite`, `n/s/m/l/x`, detect/segment/semantic/depth/classify/pose/OBB, hosted on `ultralytics/yolo-flutter-app` release `v0.6.6`.
-- Android export settings: `quantize=w8a32` (int8 weights, FP32 activations — dynamic-range, no calibration), `nms=None` (Ultralytics >=8.4.142; originally `nms=False, end2end=False`); classify `imgsz=224`, all other tasks `imgsz=640`.
+- Android export settings: `quantize=w8a32` (int8 weights, FP32 activations — dynamic-range, no calibration), `nms=False, end2end=False` (equivalent to `nms=None` with Ultralytics >=8.4.142); classify `imgsz=224`, all other tasks `imgsz=640`.
 - Android runtime: LiteRT 2.x with GPU -> CPU accelerator fallback.
 - Example UI: controls expose all seven tasks and all five model sizes; model changes use one modal loading overlay for downloads and native model reloads.
 - Bundled models: local/release builds fetch the seven `yolo26n` nano models into `example/assets/models/` at build time (gitignored, not committed; skipped under CI), so nano tasks work offline with no first-run download; larger sizes download on demand.

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -343,7 +343,7 @@ non-end-to-end LiteRT exports are still useful for GPU benchmarking (the GPU del
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 
@@ -410,7 +410,7 @@ This is the canonical record of the on-device profiling behind the Ultralytics Y
 
 - **Device (ground truth):** Samsung Galaxy S26 (`SM S9420`), Android 16 / API 36.
 - **Build:** Flutter example debug APK, package `com.ultralytics.yolo`.
-- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `quantize=8`, `nms=False`, `end2end=False`.
+- **Model:** `yolo26n_int8.tflite`, official YOLO26 detect asset, 640x640 input, `quantize=8`, `nms=None` (Ultralytics >=8.4.142; originally `nms=False, end2end=False`).
 - **Runtime:** Android LiteRT 2.x `CompiledModel` with `useGpu: true`.
 - **UI:** `YOLOShowcase` real-time camera view with the default task/size controls and threshold sliders.
 - **Numbers:** EMA-smoothed app metrics after the camera and model are warm.
@@ -509,7 +509,7 @@ The app UI correctly showed the resolver failure. To validate the camera/inferen
 ### Current Shipped Configuration
 
 - Android official assets: YOLO26 w8a32 `.tflite`, `n/s/m/l/x`, detect/segment/semantic/depth/classify/pose/OBB, hosted on `ultralytics/yolo-flutter-app` release `v0.6.6`.
-- Android export settings: `quantize=w8a32` (int8 weights, FP32 activations — dynamic-range, no calibration), `nms=False`, `end2end=False`; classify `imgsz=224`, all other tasks `imgsz=640`.
+- Android export settings: `quantize=w8a32` (int8 weights, FP32 activations — dynamic-range, no calibration), `nms=None` (Ultralytics >=8.4.142; originally `nms=False, end2end=False`); classify `imgsz=224`, all other tasks `imgsz=640`.
 - Android runtime: LiteRT 2.x with GPU -> CPU accelerator fallback.
 - Example UI: controls expose all seven tasks and all five model sizes; model changes use one modal loading overlay for downloads and native model reloads.
 - Bundled models: local/release builds fetch the seven `yolo26n` nano models into `example/assets/models/` at build time (gitignored, not committed; skipped under CI), so nano tasks work offline with no first-run download; larger sizes download on demand.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -64,6 +64,9 @@ Task and labels are auto-detected from the model's embedded metadata. If your cu
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder; iOS uses Core ML. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. non-end-to-end exports are useful for GPU benchmarking (the GPU delegate runs them in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
+from ultralytics import YOLO
+
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -64,7 +64,7 @@ Task and labels are auto-detected from the model's embedded metadata. If your cu
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder; iOS uses Core ML. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. non-end-to-end exports are useful for GPU benchmarking (the GPU delegate runs them in FP16):
 
 ```python
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -149,6 +149,9 @@ await controller.setThresholds(
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. To compare GPU FP16 throughput, export a non-end-to-end LiteRT model:
 
 ```python
+# Requires ultralytics>=8.4.142
+from ultralytics import YOLO
+
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -149,7 +149,7 @@ await controller.setThresholds(
 Android inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. To compare GPU FP16 throughput, export a non-end-to-end LiteRT model:
 
 ```python
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -124,7 +124,7 @@ final yolo = YOLO(
 On Android, inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. For GPU benchmarking, non-end-to-end exports are also useful (the GPU delegate runs them in FP16):
 
 ```python
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -124,6 +124,9 @@ final yolo = YOLO(
 On Android, inference runs on LiteRT 2.x with an automatic GPU → CPU accelerator ladder. Official int8 YOLO26 TFLite assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph; graphs the GPU cannot compile fall back to CPU. For GPU benchmarking, non-end-to-end exports are also useful (the GPU delegate runs them in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
+from ultralytics import YOLO
+
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```

--- a/doc/use_gpu_feature.md
+++ b/doc/use_gpu_feature.md
@@ -55,11 +55,11 @@ Official int8 YOLO26 LiteRT assets can compile on the LiteRT GPU path on support
 ```python
 from ultralytics import YOLO
 
-YOLO("yolo26n.pt").export(format="litert", nms=False, end2end=False, imgsz=640)
+YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)
 # Classification models use imgsz=224.
 ```
 
-Here the FP32 model runs in FP16 on the LiteRT GPU delegate, `nms=False` leaves NMS to the plugin, and `end2end=False` keeps the YOLO26 raw head for the Android LiteRT conversion path. Keep `useGpu: true` and verify the actual delegate from LiteRT logs.
+Here the FP32 model runs in FP16 on the LiteRT GPU delegate, `nms=None` selects the raw one-to-many head and leaves NMS to the plugin (requires `ultralytics>=8.4.142`). Keep `useGpu: true` and verify the actual delegate from LiteRT logs.
 
 On a Galaxy S26, the official `yolo26n_int8.tflite` compiled fully with the LiteRT OpenCL GPU delegate (`Replacing 395 out of 395 node(s) with delegate (LITERT_CL)`) and ran around **15 FPS / 32 ms** in the live camera example.
 

--- a/doc/use_gpu_feature.md
+++ b/doc/use_gpu_feature.md
@@ -53,6 +53,7 @@ NNAPI is no longer used (it is deprecated and slower).
 Official int8 YOLO26 LiteRT assets can compile on the LiteRT GPU path on supported devices, but int8 GPU coverage depends on the device driver and graph. A non-end-to-end LiteRT export is still useful for GPU benchmarking (the GPU delegate runs the FP32 graph in FP16):
 
 ```python
+# Requires ultralytics>=8.4.142
 from ultralytics import YOLO
 
 YOLO("yolo26n.pt").export(format="litert", nms=None, imgsz=640)

--- a/ios/ultralytics_yolo/Sources/ultralytics_yolo/README.md
+++ b/ios/ultralytics_yolo/Sources/ultralytics_yolo/README.md
@@ -36,8 +36,8 @@ The Flutter side can hand the iOS layer:
 
 ## Export Reminder
 
-YOLO26 models are NMS-free. This detect export uses `nms=False` and `end2end=True`, matching the output contract
-consumed by the Swift object detector:
+With `ultralytics[export-coreml]>=8.4.142`, this detect export uses `nms=False` to select the NMS-free head, matching
+the shipped Core ML assets and the Swift object detector:
 
 ```python
 from ultralytics import YOLO
@@ -45,9 +45,9 @@ from ultralytics import YOLO
 # Use 224 for classification and 640 for every other mobile task.
 # Square [640, 640] works best when one model must run in both portrait and landscape.
 # Ultralytics imgsz order is [height, width]; use [640, 384] for portrait-only or [384, 640] for landscape-only.
-YOLO("yolo26n.pt").export(format="coreml", nms=False, end2end=True, imgsz=[640, 640])
+YOLO("yolo26n.pt").export(format="coreml", nms=False, imgsz=[640, 640])
 ```
 
-Other tasks use the same square-orientation guidance. Match `imgsz` to the model contract above. The shipped Core ML
-assets use `end2end=False` for classification, semantic, and depth and `end2end=True` for detect, segment, pose, and
-OBB.
+Other tasks use the same square-orientation guidance and `nms=False`. Classification, semantic, and depth retain
+their native outputs. Use `nms=None` for raw one-to-many outputs with Swift-side NMS, or `nms=True` for embedded NMS
+on supported tasks. The `end2end` metadata field continues to describe the actual exported graph.

--- a/scripts/export-tflite-models.py
+++ b/scripts/export-tflite-models.py
@@ -8,7 +8,7 @@ w8a32 needs no calibration data, compiles on the LiteRT GPU delegate, and is the
 Usage from the repository root:
 
     uv venv --python 3.12 .venv
-    uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
+    uv pip install --torch-backend cpu "ultralytics-opencv-headless[export-litert]>=8.4.142"
     uv run python scripts/export-tflite-models.py --verify
 """
 

--- a/scripts/export-tflite-models.py
+++ b/scripts/export-tflite-models.py
@@ -139,7 +139,6 @@ def append_tflite_metadata(path: Path, model_id: str, task_name: str, task: Task
         "stride": 32,
         "format": "litert",
         "int8": False,
-        "nms": None,
         "end2end": False,
     }
     with zipfile.ZipFile(path, "a", zipfile.ZIP_DEFLATED) as zf:

--- a/scripts/export-tflite-models.py
+++ b/scripts/export-tflite-models.py
@@ -2,14 +2,13 @@
 """Export official YOLO26 LiteRT (.tflite) assets for the Flutter Android release.
 
 Uses the Ultralytics `format=litert` export (litert-torch + ai-edge-quantizer) with `quantize="w8a32"` (dynamic INT8:
-int8 weights + FP32 activations), which requires `ultralytics>=8.4.83` and runs on Linux x86 or macOS with Python>=3.10.
+int8 weights + FP32 activations), which requires `ultralytics>=8.4.142` and runs on Linux x86 or macOS with Python>=3.10.
 w8a32 needs no calibration data, compiles on the LiteRT GPU delegate, and is the smallest of the GPU-capable formats.
 
 Usage from the repository root:
 
     uv venv --python 3.12 .venv
-    uv pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
-    uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.83"
+    uv pip install "ultralytics-opencv-headless[export-litert]>=8.4.142"
     uv run python scripts/export-tflite-models.py --verify
 """
 
@@ -140,7 +139,7 @@ def append_tflite_metadata(path: Path, model_id: str, task_name: str, task: Task
         "stride": 32,
         "format": "litert",
         "int8": False,
-        "nms": False,
+        "nms": None,
         "end2end": False,
     }
     with zipfile.ZipFile(path, "a", zipfile.ZIP_DEFLATED) as zf:
@@ -188,8 +187,7 @@ def export_one(model_id: str, imgsz: int, output_dir: Path) -> None:
     YOLO(output_dir / f"{model_id}.pt").export(
         format="litert",
         quantize=QUANTIZE,
-        nms=False,
-        end2end=False,
+        nms=None,
         imgsz=imgsz,
         batch=1,
     )
@@ -233,6 +231,10 @@ def run_export_worker(model_id: str, task: TaskSpec, output_dir: Path) -> Path:
 def main() -> None:
     """Export requested YOLO LiteRT release assets."""
     args = parse_args()
+    from ultralytics import __version__
+    from ultralytics.utils.checks import check_version
+
+    check_version(__version__, ">=8.4.142", name="ultralytics", hard=True)
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     if args.worker_model_id:


### PR DESCRIPTION
LiteRT asset export now uses `nms=None` from ultralytics/ultralytics#26066 to preserve raw one-to-many outputs and Android-native NMS. Require Ultralytics >=8.4.142 before exporting, and remove the redundant fallback `nms` field while retaining `end2end=False` as the graph descriptor. Current LiteRT exports do not serialize `nms`; compatible cached assets retain their original exporter metadata.

Update every active export example and version requirement across the export script, English and Chinese READMEs, installation/model/usage/performance/troubleshooting guides, iOS bridge documentation and agent guidance. Core ML examples use `nms=False` for the existing NMS-free assets. Use `uv pip install --torch-backend cpu` to preserve CPU-only PyTorch resolution on Linux and support macOS in the same command. Historical changelog entries remain historical.

Validation:
- Installed the documented LiteRT extra in a fresh Python 3.12 environment (Ultralytics 8.4.142).
- Exported and invoked all seven official nano task models with `--verify`: detect [1,84,8400], segment [1,116,8400] plus masks, semantic [1,19,640,640], depth [1,1,640,640], classify [1,1000], pose [1,56,8400], OBB [1,20,8400].
- All seven files retain a single exporter-authored metadata entry, version 8.4.142 and end2end=false.
- All 175 existing Flutter tests passed; Dart analysis and publish dry-run passed (zero warnings).
- Fresh LiteRT exports passed real-image inference for all seven tasks. The published 8.4.104 detect asset also passed inference and remained byte-for-byte unchanged through metadata reuse.
- Both scripts reject the real installed Ultralytics 8.4.104 before creating an output directory.
- Signed Flutter iOS debug build passed. All 14 real-image cases passed through the Flutter method-channel API on the physical iPhone 17 Pro (iOS 26.6.1), including task/end2end metadata assertions and uniquely named fresh model assets. Results were saved on the phone and retrieved over USB; all 14 task/mode rows passed. Physical Android hardware is not connected; Android build, release-bundle and emulator CI passed.
- All 14 fresh Core ML variants passed real-image inference through both the shared Swift SDK and Flutter method-channel API in the simulator. The Flutter run also checked task/end2end metadata and used unique asset names to avoid reusing cached models. The native iOS release build and iPhone installation passed.

The 35-model catalogs, pinned release URLs, native decoders and shared UltralyticsYOLO dependency ranges remain unchanged. No release assets have been overwritten. Companion [iOS PR #317](https://github.com/ultralytics/yolo-ios-app/pull/317) updates the Core ML exporter and documentation.


The temporary on-device Flutter test app was removed after validation. No test harness or generated model assets are included in this PR.


## Repository documentation audit

Re-audited all 16 distinct tracked Markdown files (plus the `CLAUDE.md` symlink), all scripts, workflows, dependency manifests, export examples, and NMS/metadata references. Every Python export example parses and uses the canonical `nms` argument with the 8.4.142 version requirement documented. Historical changelog and benchmark provenance retain their original version/argument references; `end2end` graph metadata remains valid.
Completed standalone example version requirements and explicit QNN NMS guidance in both README translations and the model guide. These follow-up changes only affect documentation, so the recorded device results still apply to the same runtime and exporter code.


Claude Code Fable 5.1 (`claude-fable-5-1`, effort `xhigh`) reviewed the full diff, then re-reviewed its findings and the updated diff. Final verdict: **LGTM, no findings**, on `75d80b8a6ae297d16d7a2c2563ebdbee220d9255`. In-session full-diff review agrees.
The exact documented install requirement additionally resolves successfully under CPython 3.12.12 for Linux x86 and macOS with `--torch-backend cpu`; Linux selects CPU torch/torchvision wheels without the CUDA package stack.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated LiteRT exports to use `nms=None` with Ultralytics 8.4.142+, preserving raw outputs for Android-side NMS while aligning export metadata and documentation with the unified arguments.

### 📊 Key Changes
- The LiteRT export script now requires `ultralytics>=8.4.142`, passes `nms=None`, and retains only `end2end=False` in its added metadata.
- The export setup now uses `uv pip install --torch-backend cpu`, supporting CPU-only PyTorch resolution on Linux and macOS.
- LiteRT examples across English, Chinese, installation, model, usage, performance, troubleshooting, GPU, and agent documentation use `nms=None`; Core ML examples use `nms=False`.
- Documentation now distinguishes `nms` export configuration from `end2end` graph metadata and adds explicit QNN guidance for raw outputs with Android-side NMS.
- The exporter checks the installed Ultralytics version before creating the output directory; existing catalogs, release URLs, native decoders, dependency ranges, and release assets remain unchanged.

### 🎯 Purpose & Impact
- New LiteRT and QNN exports produce raw one-to-many outputs for Android-side NMS, while cached compatible assets retain their existing exporter metadata.
- Users following the documented export workflow must install Ultralytics 8.4.142 or newer; Core ML export guidance continues to produce NMS-free assets with `nms=False`.